### PR TITLE
Fix native cDFA extension build on Python 3.13+

### DIFF
--- a/fte/cDFA.cc
+++ b/fte/cDFA.cc
@@ -77,7 +77,14 @@ static bool pylong_to_mpz(PyObject* pylong, mpz_class& result) {
     
     // Export to bytes (big-endian)
     std::vector<unsigned char> buf(nbytes);
+    // CPython 3.13 added a trailing `with_exceptions` argument to
+    // _PyLong_AsByteArray; keep both call shapes so the extension builds
+    // across supported Python versions.
+#if PY_VERSION_HEX >= 0x030D0000
+    if (_PyLong_AsByteArray((PyLongObject*)pylong, buf.data(), nbytes, 0, 0, 1) < 0) {
+#else
     if (_PyLong_AsByteArray((PyLongObject*)pylong, buf.data(), nbytes, 0, 0) < 0) {
+#endif
         return false;
     }
     


### PR DESCRIPTION
## Summary

The native `fte.cDFA` C++ extension fails to compile on **Python 3.13 and 3.14**.

CPython 3.13 added a trailing `with_exceptions` argument to the private
`_PyLong_AsByteArray` API used in `pylong_to_mpz()`, so the call no longer
matches on newer interpreters:

```
fte/cDFA.cc:80:9: error: no matching function for call to '_PyLong_AsByteArray'
```

## Testing

Built the extension against Python 3.14 and verified round-trips through the
native backend across several formats:

```bash
FTE_BUILD_NATIVE=1 python setup.py build_ext --inplace
FTE_USE_NATIVE=1 python -c "import fte; e=fte.Encoder('^[a-z]+$',256); \
  m=b'hello world'; assert e.decode(e.encode(m))[0]==m; print('ok')"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
