### PR TITLE
ci: add Python 3.13 and 3.14 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds **Python 3.13 and 3.14** to the CI test matrix in `test.yml`, for both the
pure-Python and native jobs, on Ubuntu and macOS.

- `test-pure-python`: `3.8 … 3.12` → `3.8 … 3.14`
- `test-native`: `3.10 … 3.12` → `3.10 … 3.14`

## Dependency / stacking

The native jobs on 3.13/3.14 only build with the `_PyLong_AsByteArray` fix from
**#39**, so this PR is **stacked on top of `fix/native-build-py313`** (its base
branch) and is green as-is. After #39 merges to `master`, retarget this PR's
base to `master` — the diff is a single workflow file, so it stays clean.

Without #39, the native extension silently falls back to pure Python on 3.13+
and the "Verify using native extension" step fails — which is exactly why the
fix must land first.

## Note

Trove classifiers in `setup.py` / `pyproject.toml` still list up to
`Python :: 3.12`; bumping those to advertise 3.13/3.14 is a separate, optional
follow-up and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
