### PR TITLE
ci: add Python 3.13 and 3.14 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Adds **Python 3.13 and 3.14** to the CI test matrix in `test.yml` (both the
pure-Python and native jobs, on Ubuntu and macOS).

- `test-pure-python`: `3.8 … 3.12` → `3.8 … 3.14`
- `test-native`: `3.10 … 3.12` → `3.10 … 3.14`

The `_PyLong_AsByteArray` build fix these native jobs depend on is already on
`master` (#39), so this targets `master` directly.

> Note: this re-lands the change from #41, which was merged into its stacked
> base branch (`fix/native-build-py313`) rather than `master`, so it never
> reached `master`.

Trove classifiers in `setup.py` / `pyproject.toml` still cap at
`Python :: 3.12`; bumping those is a separate optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)