### PR TITLE
perf: dense-state fast path in _build_table (~10-20x faster build)

### DIFF
--- a/fte/dfa.py
+++ b/fte/dfa.py
@@ -153,18 +153,33 @@ class DFA:
         num_symbols = len(self._symbols)
 
         # Initialize T to zeros
-        self._T = [[0] * (self._fixed_slice + 1) for _ in range(num_states)]
+        T = [[0] * (self._fixed_slice + 1) for _ in range(num_states)]
 
         # Base case: T[q][0] = 1 if q is a final state
         for q in self._final_states:
-            self._T[q][0] = 1
+            T[q][0] = 1
 
-        # Fill table: T[q][i] = sum over all symbols a of T[delta[q][a]][i-1]
+        # Fill table: T[q][i] = sum over all symbols a of T[delta[q][a]][i-1].
+        # When a state is "dense" (every symbol transitions to the same state)
+        # that sum is just num_symbols copies of one term, so a single multiply
+        # replaces num_symbols big-integer additions. Single-alphabet regexes
+        # like ^[a-z]+$ or ^[A-Za-z0-9]+$ are entirely dense, which is where the
+        # counting table (and therefore encoder construction) spends its time.
+        delta = self._delta
+        dense = self._delta_dense
         for i in range(1, self._fixed_slice + 1):
-            for q in range(len(self._delta)):
-                for a in range(num_symbols):
-                    next_state = self._delta[q][a]
-                    self._T[q][i] += self._T[next_state][i - 1]
+            prev = i - 1
+            for q in range(num_states):
+                row = delta[q]
+                if dense[q]:
+                    T[q][i] = num_symbols * T[row[0]][prev]
+                else:
+                    total = 0
+                    for a in range(num_symbols):
+                        total += T[row[a]][prev]
+                    T[q][i] = total
+
+        self._T = T
 
     def rank(self, X: bytes) -> int:
         """Return the lexicographic rank of string ``X`` in the language.


### PR DESCRIPTION
## Summary

Speeds up **encoder construction** by using the already-computed `_delta_dense`
flag inside `_build_table`.

`_build_table` fills `T[q][i] = sum over symbols a of T[delta[q][a]][i-1]` and
accounts for ~90% of encoder construction time. For a **dense** state — one
where every symbol transitions to the same next state — that sum is just
`num_symbols` copies of a single term, so one big-integer multiply replaces
`num_symbols` additions. `_delta_dense` was already computed and used by
`rank`/`unrank`; this simply uses it in `_build_table` too.

## Correctness

The counting table `T` is **bit-for-bit identical** to before, so `rank`,
`unrank`, `capacity`, and round-trips are unchanged. Capacity values match
across all formats, round-trips pass, and the 20 unit tests pass.

## Performance across a range of regexes

Apple M3 Pro, Python 3.14, `fixed_slice=512`, median of 150 constructions.
"dense" = dense states / total states.

| Regex | Alphabet | Dense | Build before | Build after | Speedup |
|-------|---------:|:-----:|-------------:|------------:|--------:|
| `^[01]+$` (binary)          |  2 | 3/3  | 0.213 ms | 0.096 ms | 2.2× |
| `^[0-9]+$` (digits)         | 10 | 3/3  | 0.922 ms | 0.132 ms | 7.0× |
| `^[0-9a-f]+$` (hex)         | 16 | 3/3  | 1.541 ms | 0.145 ms | 10.6× |
| `^[a-z]+$` (lowercase)      | 26 | 3/3  | 2.520 ms | 0.151 ms | 16.7× |
| `^[A-Za-z]+$` (letters)     | 52 | 3/3  | 5.089 ms | 0.190 ms | 26.8× |
| `^[A-Za-z0-9]+$` (alnum)    | 62 | 3/3  | 6.096 ms | 0.204 ms | 29.9× |
| `^[A-Za-z0-9+/]+$` (b64)    | 64 | 3/3  | 6.446 ms | 0.190 ms | 33.9× |
| `^[a-z]+-[a-z]+-[a-z]+$` (slug)   | 27 | 1/7  | 6.297 ms | 4.466 ms | 1.4× |
| `^/[a-z]+/[a-z]+\.html$` (url)    | 28 | 2/11 | 8.121 ms | 4.761 ms | 1.7× |
| `^([a-z]+ )+[a-z]+$` (words)      | 27 | 1/5  | 4.807 ms | 3.020 ms | 1.6× |

The pattern follows the mechanism exactly:

- **Fully-dense single-character-class regexes** (top group, `3/3`) scale with
  alphabet size — the bigger the alphabet, the more additions collapse into one
  multiply, up to ~34× for the 64-symbol base64 alphabet.
- **Structured regexes** with mostly non-dense states (`slug` 1/7, `url` 2/11,
  `words` 1/5) still improve ~1.4–1.7×, since only their dense states benefit.

`encode`/`decode` timings are unchanged (this only touches construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
