### PR TITLE
perf: optimize rank/unrank hot loops (encode up to ~2x)

### DIFF
--- a/fte/dfa.py
+++ b/fte/dfa.py
@@ -179,34 +179,37 @@ class DFA:
             InvalidRankInput: If ``X`` has the wrong length or is not in the
                 language.
         """
-        if len(X) != self._fixed_slice:
+        n = len(X)
+        if n != self._fixed_slice:
             raise InvalidRankInput(
-                f"Input length {len(X)} != fixed_slice {self._fixed_slice}"
+                f"Input length {n} != fixed_slice {self._fixed_slice}"
             )
+
+        # Hoist attribute lookups out of the hot loop.
+        T = self._T
+        delta = self._delta
+        dense = self._delta_dense
+        sigma_reverse = self._sigma_reverse
 
         c = 0
         q = self._start_state
-        n = len(X)
 
-        for i in range(1, n + 1):
-            byte_val = X[i - 1]
-
-            if byte_val not in self._sigma_reverse:
+        for pos, byte_val in enumerate(X):
+            symbol_idx = sigma_reverse.get(byte_val)
+            if symbol_idx is None:
                 raise InvalidRankInput(f"Symbol {byte_val} not in alphabet")
 
-            symbol_idx = self._sigma_reverse[byte_val]
-
-            if self._delta_dense[q]:
-                # Optimized: all transitions from q go to same state
-                state = self._delta[q][0]
-                c += self._T[state][n - i] * symbol_idx
+            col = n - 1 - pos
+            row = delta[q]
+            if dense[q]:
+                # All transitions from q go to the same state.
+                c += T[row[0]][col] * symbol_idx
             else:
-                # Standard Goldberg-Sipser ranking
+                # Standard Goldberg-Sipser ranking.
                 for j in range(symbol_idx):
-                    state = self._delta[q][j]
-                    c += self._T[state][n - i]
+                    c += T[row[j]][col]
 
-            q = self._delta[q][symbol_idx]
+            q = row[symbol_idx]
 
         # Verify we ended in a final state
         if q not in self._final_states:
@@ -228,38 +231,46 @@ class DFA:
         Raises:
             InvalidUnrankInput: If ``c`` is out of range.
         """
-        words_in_slice = self.num_words_in_language(self._fixed_slice, self._fixed_slice)
-
-        if c < 0 or c >= words_in_slice:
+        if c < 0 or c >= self._words_in_slice:
             raise InvalidUnrankInput(
-                f"Rank {c} out of range [0, {words_in_slice})"
+                f"Rank {c} out of range [0, {self._words_in_slice})"
             )
+
+        # Hoist attribute lookups out of the hot loop.
+        T = self._T
+        delta = self._delta
+        dense = self._delta_dense
+        sigma = self._sigma
 
         result = bytearray()
         q = self._start_state
 
-        for i in range(1, self._fixed_slice + 1):
-            if self._delta_dense[q]:
-                # Optimized: all transitions from q go to same state
-                state = self._delta[q][0]
-                divisor = self._T[state][self._fixed_slice - i]
+        for col in range(self._fixed_slice - 1, -1, -1):
+            row = delta[q]
+            if dense[q]:
+                # All transitions from q go to the same state.
+                state = row[0]
+                divisor = T[state][col]
                 if divisor > 0:
-                    char_idx = c // divisor
-                    c = c % divisor
+                    char_idx, c = divmod(c, divisor)
                 else:
                     char_idx = 0
             else:
-                # Standard Goldberg-Sipser unranking
+                # Standard Goldberg-Sipser unranking; cache T[state][col] so it
+                # is read once per step instead of twice.
                 char_idx = 0
-                state = self._delta[q][char_idx]
-
-                while c >= self._T[state][self._fixed_slice - i]:
-                    c -= self._T[state][self._fixed_slice - i]
+                state = row[0]
+                count = T[state][col]
+                while c >= count:
+                    c -= count
                     char_idx += 1
-                    state = self._delta[q][char_idx]
+                    state = row[char_idx]
+                    count = T[state][col]
 
-            result.append(self._sigma[char_idx])
-            q = self._delta[q][char_idx] if not self._delta_dense[q] else state
+            result.append(sigma[char_idx])
+            # In both branches `state` is delta[q][char_idx] (they are all equal
+            # for a dense state), so it is the next state.
+            q = state
 
         # Verify we ended in a final state
         if q not in self._final_states:


### PR DESCRIPTION
## Summary

Behavior-preserving micro-optimizations to the per-message ranking code in
`fte/dfa.py`:

- **Hoist attribute lookups** (`self._T`, `_delta`, `_delta_dense`, `_sigma`,
  `_sigma_reverse`) into locals so the inner loops don't repeat them.
- **`rank()`**: one dict `.get()` instead of `in` + `[]`; reuse the `delta[q]`
  row.
- **`unrank()`**: `divmod()` so the dense path does a single big-integer
  division instead of a separate `//` and `%`; cache `T[state][col]` in the
  non-dense loop (read once per step, not twice); use the precomputed
  `_words_in_slice` for the bounds check instead of recomputing it every call.

## Correctness

`rank`/`unrank` outputs are identical. Verified: capacity values unchanged,
round-trips pass, `rank(unrank(r)) == r` over 2000 random ranks, and the 20
unit tests pass.

## Performance across a range of regexes

Apple M3 Pro, Python 3.14, `fixed_slice=512`, median of 150 ops. `encode()`
calls `unrank()` (the bigger win, from `divmod`); `decode()` calls `rank()`.

| Regex | enc before | enc after | enc × | dec before | dec after | dec × |
|-------|-----------:|----------:|:-----:|-----------:|----------:|:-----:|
| `^[01]+$` (binary)       | 0.092 | 0.079 | 1.16× | 0.087 | 0.078 | 1.12× |
| `^[0-9]+$` (digits)      | 0.183 | 0.122 | 1.50× | 0.111 | 0.101 | 1.10× |
| `^[0-9a-f]+$` (hex)      | 0.210 | 0.140 | 1.50× | 0.111 | 0.108 | 1.03× |
| `^[a-z]+$` (lowercase)   | 0.245 | 0.159 | 1.54× | 0.121 | 0.120 | 1.01× |
| `^[A-Za-z]+$` (letters)  | 0.277 | 0.169 | 1.64× | 0.135 | 0.132 | 1.02× |
| `^[A-Za-z0-9]+$` (alnum) | 0.290 | 0.172 | 1.69× | 0.136 | 0.135 | 1.01× |
| `^[A-Za-z0-9+/]+$` (b64) | 0.291 | 0.187 | 1.56× | 0.138 | 0.133 | 1.04× |
| `^[a-z]+-[a-z]+-[a-z]+$` (slug) | 0.664 | 0.539 | 1.23× | 0.654 | 0.604 | 1.08× |
| `^/[a-z]+/[a-z]+\.html$` (url)  | 0.742 | 0.574 | 1.29× | 0.716 | 0.620 | 1.16× |
| `^([a-z]+ )+[a-z]+$` (words)    | 0.680 | 0.546 | 1.25× | 0.681 | 0.561 | 1.21× |

(times in ms per op)

- **`encode()` / `unrank`** improves **1.2–1.7×** across the board; the win is
  largest for wide single-class alphabets, where the dense `divmod` replaces
  the separate `//` + `%`.
- **`decode()` / `rank`** improves modestly (≈1.0–1.2×); its dense path was
  already a single multiply, so only the hoisting/`.get()` overhead is shaved.
- The `encode` win **grows with `fixed_slice`** (bigger integers → division
  dominates): for `^[a-z]+$`, `encode` at `fixed_slice=2048` goes 3.26 ms →
  1.57 ms (~2.1×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
