### PR TITLE
perf(dfa): faster rank/unrank (per-message hot path)

### DIFF
--- a/fte/dfa.py
+++ b/fte/dfa.py
@@ -184,35 +184,56 @@ class DFA:
                 f"Input length {len(X)} != fixed_slice {self._fixed_slice}"
             )
 
-        c = 0
         q = self._start_state
         n = len(X)
+
+        # Hoist attribute lookups out of the per-character loop.
+        T = self._T
+        delta = self._delta
+        dense = self._delta_dense
+        sigma_reverse = self._sigma_reverse
+
+        # Collect each position's contribution, then sum them smallest-first.
+        # Earlier positions carry far larger weights than later ones, so adding
+        # them big-first (as a running ``c += ...`` does) forces every addition
+        # to full width. Deferring the sum lets us add the small tail first and
+        # keep the running total narrow for most of the additions. The inner
+        # non-dense loop also accumulates into a small local before appending,
+        # instead of repeatedly widening the grand total.
+        terms = []
+        append = terms.append
 
         for i in range(1, n + 1):
             byte_val = X[i - 1]
 
-            if byte_val not in self._sigma_reverse:
+            symbol_idx = sigma_reverse.get(byte_val, -1)
+            if symbol_idx < 0:
                 raise InvalidRankInput(f"Symbol {byte_val} not in alphabet")
 
-            symbol_idx = self._sigma_reverse[byte_val]
+            delta_q = delta[q]
+            col = n - i
 
-            if self._delta_dense[q]:
+            if dense[q]:
                 # Optimized: all transitions from q go to same state
-                state = self._delta[q][0]
-                c += self._T[state][n - i] * symbol_idx
+                if symbol_idx:
+                    append(T[delta_q[0]][col] * symbol_idx)
             else:
                 # Standard Goldberg-Sipser ranking
+                s = 0
                 for j in range(symbol_idx):
-                    state = self._delta[q][j]
-                    c += self._T[state][n - i]
+                    s += T[delta_q[j]][col]
+                if s:
+                    append(s)
 
-            q = self._delta[q][symbol_idx]
+            q = delta_q[symbol_idx]
 
         # Verify we ended in a final state
         if q not in self._final_states:
             raise InvalidRankInput("String does not end in accepting state")
 
-        return c
+        # ``terms`` runs from largest weight (position 1) to smallest; summing
+        # the reversed sequence adds smallest-first.
+        return sum(reversed(terms))
 
     def unrank(self, c: int) -> bytes:
         """Return the string at lexicographic rank ``c`` in the language.
@@ -228,7 +249,7 @@ class DFA:
         Raises:
             InvalidUnrankInput: If ``c`` is out of range.
         """
-        words_in_slice = self.num_words_in_language(self._fixed_slice, self._fixed_slice)
+        words_in_slice = self._words_in_slice
 
         if c < 0 or c >= words_in_slice:
             raise InvalidUnrankInput(
@@ -237,29 +258,42 @@ class DFA:
 
         result = bytearray()
         q = self._start_state
+        fixed_slice = self._fixed_slice
 
-        for i in range(1, self._fixed_slice + 1):
-            if self._delta_dense[q]:
+        # Hoist attribute lookups out of the per-character loop.
+        T = self._T
+        delta = self._delta
+        dense = self._delta_dense
+        sigma = self._sigma
+
+        for i in range(1, fixed_slice + 1):
+            delta_q = delta[q]
+            col = fixed_slice - i
+
+            if dense[q]:
                 # Optimized: all transitions from q go to same state
-                state = self._delta[q][0]
-                divisor = self._T[state][self._fixed_slice - i]
-                if divisor > 0:
-                    char_idx = c // divisor
-                    c = c % divisor
+                state = delta_q[0]
+                divisor = T[state][col]
+                if divisor:
+                    # divmod computes quotient and remainder in one division.
+                    char_idx, c = divmod(c, divisor)
                 else:
                     char_idx = 0
             else:
                 # Standard Goldberg-Sipser unranking
                 char_idx = 0
-                state = self._delta[q][char_idx]
-
-                while c >= self._T[state][self._fixed_slice - i]:
-                    c -= self._T[state][self._fixed_slice - i]
+                state = delta_q[0]
+                threshold = T[state][col]
+                while c >= threshold:
+                    c -= threshold
                     char_idx += 1
-                    state = self._delta[q][char_idx]
+                    state = delta_q[char_idx]
+                    threshold = T[state][col]
 
-            result.append(self._sigma[char_idx])
-            q = self._delta[q][char_idx] if not self._delta_dense[q] else state
+            result.append(sigma[char_idx])
+            # In both branches ``state`` is delta[q][char_idx], so it is the
+            # next state regardless of density.
+            q = state
 
         # Verify we ended in a final state
         if q not in self._final_states:


### PR DESCRIPTION
## Summary

The per-message cost of FTE is dominated by `DFA.rank` (decode) and `DFA.unrank` (encode) doing big-integer arithmetic. Two changes:

**`unrank`**
- Replace `c // divisor` + `c % divisor` with a single `divmod(c, divisor)` — one big-integer division instead of two (this dominates `encode`).
- Use the already-cached `self._words_in_slice` instead of recomputing `num_words_in_language()` per call.
- Collapse the redundant post-step next-state lookup to `q = state` (equivalent in both branches).

**`rank`**
- Hoist `self._T/_delta/_delta_dense/_sigma_reverse` into locals; lift `col` and `delta[q]` out of the inner loop.
- **Sum smallest-first.** Early positions carry far larger weights, so the old running `c += …` forced every addition to full width. Collecting contributions and doing `sum(reversed(terms))` adds the small tail first, keeping the running total narrow for most additions; the non-dense inner loop now accumulates into a small local first.

## Benchmarks — encode / decode (ms)

Median of 3 interleaved runs of `benchmark.py -n 200 -w 8` (bytecode cache cleared between runs, Apple M3 Pro / CPython 3.14.6). *Before* = merge-base `master`, *after* = this branch.

| Format | slice | enc before | enc after | spd | dec before | dec after | spd |
|---|--:|--:|--:|--:|--:|--:|--:|
| Binary | 512 | 0.099 | 0.078 | 1.27× | 0.091 | 0.073 | 1.25× |
| Hex | 256 | 0.088 | 0.061 | 1.44× | 0.063 | 0.058 | 1.09× |
| Lowercase | 256 | 0.097 | 0.069 | 1.41× | 0.061 | 0.060 | 1.02× |
| Alphanumeric | 192 | 0.079 | 0.055 | 1.44× | 0.056 | 0.051 | 1.10× |
| URL path | 128 | 0.154 | 0.113 | 1.36× | 0.119 | 0.092 | 1.29× |
| Words | 120 | 0.138 | 0.104 | 1.33× | 0.113 | 0.090 | 1.26× |

**`fixed_slice` sweep** (`^[a-z]+$`) — gains grow with output length, since larger integers make the `divmod`/summation savings dominate:

| slice | enc before | enc after | spd | dec before | dec after | spd |
|--:|--:|--:|--:|--:|--:|--:|
| 128 | 0.048 | 0.039 | 1.23× | 0.040 | 0.040 | 1.00× |
| 256 | 0.089 | 0.071 | 1.25× | 0.062 | 0.060 | 1.03× |
| 512 | 0.240 | 0.161 | 1.49× | 0.122 | 0.119 | 1.03× |
| 1024 | 0.849 | 0.474 | 1.79× | 0.386 | 0.315 | 1.23× |
| 2048 | 3.085 | 1.658 | **1.86×** | 1.189 | 1.007 | 1.18× |

`encode` (unrank-bound) sees the larger win from `divmod`; `decode` (rank-bound) improves most on non-dense formats and large slices, where the reverse-sum keeps the running total narrow.

## Correctness — no functional change

- All 20 unit tests pass.
- Verified against the previous implementation across **15 regexes × 9 slices**: **5488 matching `rank`/`unrank` round-trips**, identical counting tables, and identical error/exception paths (wrong length, out-of-alphabet symbol, out-of-range rank).

## Independence

Touches only `DFA.rank` / `DFA.unrank`. Non-overlapping with the build-table (#47) and encoder-cache (#49) PRs — mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
