### PR TITLE
perf(encoder): cache constant maximumBytesToRank

### DIFF
--- a/fte/encoder.py
+++ b/fte/encoder.py
@@ -84,6 +84,11 @@ class DfaEncoderObject:
         self._dfa = DFA(dfa, self._fixed_slice)
         self._encrypter = fte.encrypter.Encrypter(K1, K2)
 
+        # Capacity is fixed for the life of the encoder, so the number of
+        # bytes we can rank is constant; compute it once here instead of on
+        # every encode()/decode() call.
+        self._maximumBytesToRank = int(math.floor(self.getCapacity() / 8.0))
+
     def getCapacity(self) -> int:
         """Get the capacity of the language in bits.
         
@@ -130,7 +135,7 @@ class DfaEncoderObject:
         else:
             ciphertext = self._encrypter.encrypt(X)
 
-        maximumBytesToRank = int(math.floor(self.getCapacity() / 8.0))
+        maximumBytesToRank = self._maximumBytesToRank
         unrank_payload_len = (
             maximumBytesToRank - DfaEncoderObject._COVERTEXT_HEADER_LEN_CIPHERTEXT
         )
@@ -196,7 +201,7 @@ class DfaEncoderObject:
                 "Covertext is shorter than fixed_slice, can't decode."
             )
 
-        maximumBytesToRank = int(math.floor(self.getCapacity() / 8.0))
+        maximumBytesToRank = self._maximumBytesToRank
 
         rank_payload = self._dfa.rank(covertext[:self._fixed_slice])
         X = fte.bit_ops.long_to_bytes(rank_payload)


### PR DESCRIPTION
## Summary

`getCapacity()` returns the DFA's fixed capacity, so `int(math.floor(getCapacity() / 8.0))` is constant for the life of a `DfaEncoderObject`. It was being recomputed on **every** `encode()` and `decode()` call. This computes it once in `__init__` (`self._maximumBytesToRank`) and reuses it.

This is a **cleanup, not a measurable speedup** — see below. Removing a `math.floor`/division per call is negligible next to the DFA big-integer arithmetic that dominates each message; the value is not recomputing a constant (and it can't drift from `capacity`).

## Benchmarks — encode / decode (ms)

Median of 3 interleaved runs of `benchmark.py -n 200 -w 8` (bytecode cache cleared between runs, Apple M3 Pro / CPython 3.14.6). *Before* = merge-base `master`, *after* = this branch.

| Format | slice | enc before | enc after | spd | dec before | dec after | spd |
|---|--:|--:|--:|--:|--:|--:|--:|
| Binary | 512 | 0.099 | 0.101 | 0.98× | 0.091 | 0.092 | 0.99× |
| Hex | 256 | 0.088 | 0.090 | 0.98× | 0.063 | 0.063 | 1.00× |
| Lowercase | 256 | 0.097 | 0.099 | 0.98× | 0.061 | 0.064 | 0.95× |
| Alphanumeric | 192 | 0.079 | 0.077 | 1.03× | 0.056 | 0.054 | 1.04× |
| URL path | 128 | 0.154 | 0.152 | 1.01× | 0.119 | 0.120 | 0.99× |
| Words | 120 | 0.138 | 0.134 | 1.03× | 0.113 | 0.102 | 1.11× |

The spread straddles 1.0× in both directions — the difference is **within measurement noise** at these payload sizes (sub-0.1 ms figures carry ~±0.005 ms jitter). Merge this for the code hygiene, not for the numbers.

## Correctness

- All 20 unit tests pass. No behavioral change.

## Independence

Touches only `fte/encoder.py`. Non-overlapping with the two `dfa.py` PRs (#47, #48) — mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
