### PR TITLE
Security hardening: CodeQL, Dependabot, SECURITY.md, pinned/least-privilege workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Python dependencies (pyproject.toml / setup.py / requirements.txt at the repo root).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, Mondays at 03:27 UTC.
+    - cron: '27 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    # Deterministic check name used as a required status check on the default branch.
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload CodeQL results to the code-scanning API.
+      security-events: write
+      # Needed by CodeQL to read the Actions workflow run.
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,19 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -36,7 +39,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/
@@ -55,13 +58,13 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -79,10 +82,10 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
@@ -17,10 +20,10 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,8 +41,25 @@ jobs:
           python -c "import fte; e = fte.Encoder(r'^[a-z]+$', 256); m = b'hello world'; assert e.decode(e.encode(m))[0] == m; print('ok')"
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  # Aggregate gate: single deterministic check for branch protection. It depends
+  # on every matrix leg of `test`, so requiring only this context gates on the
+  # whole matrix while surviving changes to the OS/Python combinations.
+  all-tests:
+    name: All tests passed
+    if: ${{ always() }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all test matrix jobs succeeded
+        if: ${{ needs.test.result != 'success' }}
+        run: |
+          echo "Test matrix result: ${{ needs.test.result }}"
+          exit 1
+      - name: Success
+        run: echo "All test matrix jobs passed."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released line only. Older versions do
+not receive backported patches — please upgrade to a supported version.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Report vulnerabilities privately through GitHub's private vulnerability
+reporting:
+
+1. Go to the repository's [**Security** tab](https://github.com/kpdyer/libfte/security).
+2. Click **Report a vulnerability** to open a private advisory
+   (direct link: <https://github.com/kpdyer/libfte/security/advisories/new>).
+3. Include as much detail as you can:
+   - the affected version(s) and platform,
+   - a description of the issue and its impact,
+   - steps to reproduce or a proof of concept,
+   - any suggested remediation.
+
+You will receive a response acknowledging the report. If the issue is
+confirmed, a fix will be prepared and released, and the advisory will be
+published (crediting you unless you prefer to remain anonymous).
+
+Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
Adds in-repo security hardening. Companion to the repo-level settings enabled out-of-band (secret scanning + push protection, private vulnerability reporting, branch protection on `master`).

## What's in this PR

### New: CodeQL code scanning — `.github/workflows/codeql.yml`
- Language: **Python** (the repo's only language), query suite **`security-extended`**.
- Triggers: push + PR to `master`, plus a **weekly** schedule (Mon 03:27 UTC).
- Deterministic analyze job name **`Analyze (Python)`** so it can be wired as a required status check.
- Least-privilege: top-level `contents: read`; job elevates only `security-events: write` + `actions: read`.

### New: Dependabot — `.github/dependabot.yml`
- **`pip`** (root) — weekly version updates.
- **`github-actions`** — weekly, **grouped** into a single PR.

### New: `SECURITY.md`
- Supported-versions table (0.2.x supported).
- Report privately via **GitHub private vulnerability reporting** (Security tab → Report a vulnerability).

### Hardened existing workflows (`test.yml`, `publish.yml`)
- **Every `uses:` pinned to a full commit SHA** with a `# vN` comment (checkout, setup-python, upload/download-artifact, codecov-action, codeql-action, gh-action-pypi-publish).
- Added top-level **`permissions: contents: read`** to both workflows.
- **Preserved** job-level `id-token: write` in `publish.yml` (PyPI trusted publishing).
- Added an aggregate **`All tests passed`** gate job in `test.yml` that `needs:` the full test matrix — this is the single required status check on `master`, so it survives changes to the OS/Python matrix.

## Notes
- `Dependabot alerts` and `Dependabot security updates` were already enabled and were left untouched.
- No changes to the actual build/test logic — only workflow metadata, permissions, and pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)