### PR TITLE
Add ranked-format encoding engine (FTE + RankedFormat)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.md
 include README_PYPI.md
 include BUILDING.md
 include fte/_version.txt
+include fte/py.typed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Format-Transforming Encryption (FTE) transforms ciphertext to match arbitrary formats specified by regular expressions. Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify—hexadecimal strings, alphanumeric tokens, or any pattern expressible as a regex.
+Format-Transforming Encryption (FTE) transforms ciphertext to match a target format—one given by a regular expression, or by any *ranked-format* provider you supply. Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify—hexadecimal strings, alphanumeric tokens, any pattern expressible as a regex, or a custom format such as decimal text or a domain-specific grammar.
 
 This is useful for:
 - **Protocol obfuscation**: Make encrypted traffic look like benign data
@@ -82,6 +82,50 @@ ciphertext = fte.encode(b'secret', regex='^[a-z]+$', fixed_slice=128)
 plaintext, _ = fte.decode(ciphertext, regex='^[a-z]+$', fixed_slice=128)
 ```
 
+### Ranked-Format Providers
+
+The `FTE` API accepts any structural `RankedFormat`: an object with reversible
+`rank()` and `unrank()` methods. No inheritance, registration, or dependency
+between libfte and the provider is required:
+
+```python
+import fte
+
+
+class DecimalText:
+    def rank(self, value: str, /) -> int:
+        if not value.isascii() or not value.isdigit():
+            raise ValueError("not canonical decimal text")
+        if value != "0" and value.startswith("0"):
+            raise ValueError("not canonical decimal text")
+        return int(value)
+
+    def unrank(self, index: int, /) -> str:
+        if type(index) is not int or index < 0:
+            raise ValueError("invalid rank")
+        return str(index)
+
+key = bytes.fromhex(
+    "000102030405060708090a0b0c0d0e0f"
+    "101112131415161718191a1b1c1d1e1f"
+)
+# Demonstration key only; load a securely shared secret in production.
+encoder = fte.FTE(format=DecimalText(), key=key)
+
+covertext: str = encoder.encode(b"secret")
+plaintext = encoder.decode(covertext)
+
+assert plaintext == b"secret"
+```
+
+`FTE` consumes and returns one complete covertext value. It has no generic
+`fixed_slice`, overflow body, or stream remainder. The two endpoints must use
+the same key and compatible ranked-format ordering. Treat returned covertext as
+a canonical, atomic value: normalization or other edits alter its rank.
+
+See the [ranked-format provider API](docs/formats.md) for the complete provider
+contract and a conformance checklist.
+
 See the [`examples/`](examples/) directory for more use cases.
 
 ## API Reference
@@ -107,6 +151,42 @@ fte.Encoder(regex: str, fixed_slice: int, key: bytes = None)
 | `encode(plaintext: bytes) -> bytes` | Encrypt and format plaintext |
 | `decode(ciphertext: bytes) -> (bytes, bytes)` | Decrypt, returns (plaintext, remainder) |
 | `capacity` | Property: bits of data that fit in `fixed_slice` |
+
+### `fte.FTE`
+
+Bidirectional FTE over any structural `RankedFormat[T]`.
+
+```python
+fte.FTE(
+    *,
+    format: RankedFormat[T],
+    key: bytes,
+    max_plaintext_bytes: int = 1_048_576,
+)
+```
+
+| Method | Description |
+|--------|-------------|
+| `encode(plaintext: bytes) -> T` | Encrypt and unrank into a covertext value |
+| `decode(covertext: T) -> bytes` | Rank and decrypt one complete value |
+| `max_plaintext_bytes` | Local resource ceiling; format capacity may be lower |
+
+### `fte.RankedFormat`
+
+The ranked-format extension protocol:
+
+```python
+class RankedFormat(Protocol[T]):
+    def rank(self, value: T, /) -> int: ...
+    def unrank(self, index: int, /) -> T: ...
+```
+
+Formats must use contiguous non-negative ranks and satisfy
+`rank(unrank(i)) == i` and `unrank(rank(value)) == value`.
+
+A finite provider may additionally implement `FiniteRankedFormat` by exposing
+an exact positive `cardinality`; libfte then performs capacity checks before
+encryption.
 
 ### Convenience Functions
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -9,7 +9,7 @@
 
 ## What is FTE?
 
-Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify with a regular expression—hex strings, alphanumeric tokens, or any regex-expressible pattern.
+Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify—via a regular expression, or any `RankedFormat` provider you supply—so it can look like hex strings, alphanumeric tokens, any regex-expressible pattern, or a custom format of your own.
 
 ## Installation
 
@@ -38,6 +38,41 @@ print(ciphertext.decode())
 plaintext, _ = encoder.decode(ciphertext)
 # → b'Attack at dawn'
 ```
+
+### Ranked-Format Providers
+
+`FTE` accepts any object implementing the structural `RankedFormat` protocol:
+reversible `rank()` and `unrank()` methods. Providers need no inheritance,
+registration, or runtime dependency on libfte:
+
+```python
+import secrets
+
+import fte
+
+
+class DecimalText:
+    def rank(self, value: str, /) -> int:
+        if not value.isascii() or not value.isdigit():
+            raise ValueError("not canonical decimal text")
+        if value != "0" and value.startswith("0"):
+            raise ValueError("not canonical decimal text")
+        return int(value)
+
+    def unrank(self, index: int, /) -> str:
+        if type(index) is not int or index < 0:
+            raise ValueError("invalid rank")
+        return str(index)
+
+shared_32_byte_key = secrets.token_bytes(32)
+encoder = fte.FTE(format=DecimalText(), key=shared_32_byte_key)
+covertext: str = encoder.encode(b"secret")
+assert encoder.decode(covertext) == b"secret"
+```
+
+The key and exact ranked-format ordering must match at both endpoints. Generic
+FTE framing exposes plaintext length through the rank and guarantees format
+membership, not a uniform distribution over unused provider capacity.
 
 ## Use Cases
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,0 +1,104 @@
+# Ranked-format providers
+
+`fte.FTE` separates cryptography from covertext generation at one narrow
+boundary: a non-negative integer rank. libfte owns encryption, authentication,
+versioned byte framing, and bytes-to-integer conversion. A format provider owns
+only the reversible mapping between ranks and canonical covertext values.
+
+## Interface
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class RankedFormat(Protocol[T]):
+    def rank(self, value: T, /) -> int: ...
+    def unrank(self, index: int, /) -> T: ...
+
+class FiniteRankedFormat(RankedFormat[T], Protocol[T]):
+    @property
+    def cardinality(self) -> int: ...
+```
+
+This is a structural protocol. Providers do not inherit from libfte, register
+plugins, or import libfte at runtime. An existing object with compatible methods
+already conforms. `cardinality` is optional; when supplied, it must be the exact
+positive size of the contiguous rank space `range(cardinality)`. libfte uses it
+to reject messages that cannot always fit before performing encryption.
+
+## Required behavior
+
+A provider must satisfy all of these rules:
+
+1. Ranks are exact Python `int` values, never `bool`, and are non-negative.
+2. Supported ranks are contiguous and start at zero.
+3. `rank(unrank(index)) == index` for every supported index.
+4. `unrank(rank(value)) == value` for every canonical covertext value.
+5. Both operations are deterministic and perform no randomness, encryption,
+   key handling, network I/O, or text normalization.
+6. Values outside the canonical format and unsupported indexes are rejected.
+7. The ordering is a wire-level compatibility contract. Both endpoints must
+   use implementations with identical ranking behavior.
+
+`unrank()` failures during encoding become `fte.FormatCapacityError`. Invalid
+values or failures during ranking become `fte.InvalidCovertextError`. Returning
+a non-integer or negative rank is a provider bug and raises
+`fte.FormatContractError`. Original provider exceptions are retained as causes.
+
+## Example provider
+
+```python
+class LowerHex:
+    def rank(self, value: str, /) -> int:
+        if not value:
+            raise ValueError("not canonical lowercase hex")
+        index = int(value, 16)
+        if index < 0 or format(index, "x") != value:
+            raise ValueError("not canonical lowercase hex")
+        return index
+
+    def unrank(self, index: int, /) -> str:
+        if type(index) is not int or index < 0:
+            raise ValueError("invalid rank")
+        return format(index, "x")
+```
+
+Use it without an adapter:
+
+```python
+from fte import FTE
+
+encoder = FTE(format=LowerHex(), key=shared_32_byte_key)
+covertext = encoder.encode(b"hello")
+assert encoder.decode(covertext) == b"hello"
+```
+
+`FTE` defaults to a 1 MiB plaintext resource limit. Set
+`max_plaintext_bytes` lower for expensive formats or explicitly raise it for a
+trusted high-capacity provider. This is a resource ceiling, not a promise that
+the selected provider can represent every message up to that size. Decode
+rejects ranks beyond the corresponding bound before converting them back into
+a potentially large byte string.
+
+The version-one frame is variable length. Anyone who can rank a covertext can
+therefore infer its exact plaintext byte length without knowing the key. The
+mapping guarantees membership in the provider's language, but it is not uniform
+over unused rank capacity when a finite provider is much larger than the
+message requires. Applications needing length hiding or a target distribution
+must add an appropriate fixed-size record/padding layer before `FTE.encode`.
+
+`FTE.decode` is not constant-time: it rejects malformed framing, length, and
+padding before verifying the authentication tag, so rejection latency depends on
+why a value was rejected. This is safe under FTE's threat model, where an
+on-path observer sees covertext but has no decode oracle. Do not expose `decode`
+directly as a remote timing oracle to untrusted callers.
+
+## Provider checklist
+
+- Test both inverse laws at representative and boundary ranks.
+- Test rejection of noncanonical values and unsupported ranks.
+- Document the native covertext type and ordering compatibility version.
+- Document practical size, time, memory, and concurrency limits.
+- Bound work performed while ranking attacker-controlled values.
+- Keep transport framing and streaming outside the ranked-format object.

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -1,16 +1,16 @@
 """FTE - Format-Transforming Encryption library.
 
 This library implements Format-Transforming Encryption (FTE), a cryptographic
-primitive that allows encoding ciphertexts as strings matching a specified
-regular language.
+primitive that encodes ciphertexts as values from a built-in regular language
+or a custom ranked format.
 
 Example usage:
     >>> import fte
-    >>> 
+    >>>
     >>> encoder = fte.Encoder('^[a-z]+$', 128)
     >>> ciphertext = encoder.encode(b'secret message')
     >>> plaintext, _ = encoder.decode(ciphertext)
-    >>> 
+    >>>
     >>> assert plaintext == b'secret message'
 
 See the paper "Protocol Misidentification Made Easy with Format-Transforming
@@ -24,33 +24,57 @@ import regex2dfa
 
 from fte.encoder import DfaEncoder
 from fte.encrypter import Encrypter
+from fte.format import (
+    FTE,
+    FTEError,
+    FiniteRankedFormat,
+    FormatCapacityError,
+    FormatContractError,
+    InvalidCovertextError,
+    MessageTooLargeError,
+    RankedFormat,
+)
 
 __version__ = (Path(__file__).parent / '_version.txt').read_text().strip()
 __author__ = 'Kevin P. Dyer'
 __email__ = 'kpdyer@gmail.com'
 
-__all__ = ['Encoder', 'DfaEncoder', 'Encrypter', 'encode', 'decode']
+__all__ = [
+    'Encoder',
+    'FTE',
+    'FTEError',
+    'FiniteRankedFormat',
+    'FormatCapacityError',
+    'FormatContractError',
+    'InvalidCovertextError',
+    'MessageTooLargeError',
+    'RankedFormat',
+    'DfaEncoder',
+    'Encrypter',
+    'encode',
+    'decode',
+]
 
 
 class Encoder:
     """Format-Transforming Encryption encoder.
-    
+
     This is the main interface for FTE. It encrypts data and formats the
     ciphertext to match a specified regular expression.
-    
+
     Args:
         regex: A regular expression defining the output format.
             Examples: '^[a-z]+$', '^[0-9a-f]+$', '^[A-Za-z0-9]+$'
         fixed_slice: Length of the formatted output string.
         key: Optional 32-byte key (16 bytes encryption + 16 bytes MAC).
             If not provided, random keys are generated.
-    
+
     Example:
         >>> encoder = fte.Encoder('^[0-9a-f]+$', 128)
         >>> ciphertext = encoder.encode(b'secret')
         >>> plaintext, _ = encoder.decode(ciphertext)
     """
-    
+
     def __init__(
         self,
         regex: str,
@@ -59,10 +83,10 @@ class Encoder:
     ):
         self.regex = regex
         self.fixed_slice = fixed_slice
-        
+
         # Convert regex to DFA
         dfa = regex2dfa.regex2dfa(regex)
-        
+
         # Split key into K1 (encryption) and K2 (MAC) if provided
         if key is not None:
             if len(key) != 32:
@@ -70,33 +94,33 @@ class Encoder:
             K1, K2 = key[:16], key[16:]
         else:
             K1, K2 = None, None
-        
+
         self._encoder = DfaEncoder(dfa, fixed_slice, K1=K1, K2=K2)
-    
+
     def encode(self, plaintext: bytes, seed: Optional[bytes] = None) -> bytes:
         """Encrypt and encode plaintext to match the regex format.
-        
+
         Args:
             plaintext: The data to encrypt.
             seed: Optional 8-byte seed for deterministic output.
-        
+
         Returns:
             Ciphertext formatted to match the regex.
         """
         return self._encoder.encode(plaintext, seed=seed)
-    
+
     def decode(self, ciphertext: bytes) -> Tuple[bytes, bytes]:
         """Decode and decrypt ciphertext.
-        
+
         Args:
             ciphertext: The formatted ciphertext to decrypt.
-        
+
         Returns:
             A tuple of (plaintext, remainder) where remainder is any
             extra data after the decoded message.
         """
         return self._encoder.decode(ciphertext)
-    
+
     @property
     def capacity(self) -> int:
         """Get the capacity in bits."""
@@ -114,16 +138,16 @@ def encode(
     key: Optional[bytes] = None
 ) -> bytes:
     """Encode plaintext using FTE (convenience function).
-    
+
     Args:
         plaintext: The data to encrypt.
         regex: Output format as a regular expression.
         fixed_slice: Length of formatted output.
         key: Optional 32-byte key.
-    
+
     Returns:
         Ciphertext formatted to match the regex.
-    
+
     Example:
         >>> ciphertext = fte.encode(b'secret', regex='^[0-9a-f]+$')
     """
@@ -140,16 +164,16 @@ def decode(
     key: Optional[bytes] = None
 ) -> Tuple[bytes, bytes]:
     """Decode ciphertext using FTE (convenience function).
-    
+
     Args:
         ciphertext: The formatted ciphertext.
         regex: The regex used for encoding (must match).
         fixed_slice: The fixed_slice used for encoding (must match).
         key: The key used for encoding (must match).
-    
+
     Returns:
         A tuple of (plaintext, remainder).
-    
+
     Example:
         >>> plaintext, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$')
     """

--- a/fte/format.py
+++ b/fte/format.py
@@ -1,0 +1,272 @@
+"""Generic FTE support for pluggable ranked formats."""
+
+from __future__ import annotations
+
+from typing import Generic, Protocol, TypeVar, runtime_checkable
+
+from fte.encrypter import (
+    CiphertextTypeError,
+    Encrypter,
+    RecoverableDecryptionError,
+    UnrecoverableDecryptionError,
+)
+
+
+__all__ = [
+    "FTE",
+    "FTEError",
+    "FiniteRankedFormat",
+    "FormatCapacityError",
+    "FormatContractError",
+    "InvalidCovertextError",
+    "MessageTooLargeError",
+    "RankedFormat",
+]
+
+
+Covertext = TypeVar("Covertext")
+
+
+class FTEError(Exception):
+    """Base class for errors raised by the generic format API."""
+
+
+class FormatContractError(FTEError):
+    """Raised when a format violates the :class:`RankedFormat` contract."""
+
+
+class FormatCapacityError(FTEError):
+    """Raised when a format cannot represent an encrypted payload rank."""
+
+
+class MessageTooLargeError(FTEError):
+    """Raised when plaintext exceeds the configured resource limit."""
+
+
+class InvalidCovertextError(FTEError):
+    """Raised when a format value cannot be authenticated and decoded."""
+
+
+@runtime_checkable
+class RankedFormat(Protocol[Covertext]):
+    """A deterministic, reversible ordering of canonical covertext values.
+
+    A conforming format must provide a contiguous zero-based rank space and
+    satisfy both inverse laws for every supported rank and canonical value::
+
+        format.rank(format.unrank(index)) == index
+        format.unrank(format.rank(value)) == value
+
+    The ordering is part of the wire format. Sender and receiver must therefore
+    use compatible implementations and versions. Implementations should reject
+    values outside their canonical format and indexes outside their capacity.
+    """
+
+    def rank(self, value: Covertext, /) -> int:
+        """Return the non-negative integer assigned to ``value``."""
+
+        ...
+
+    def unrank(self, index: int, /) -> Covertext:
+        """Return the canonical value assigned to non-negative ``index``."""
+
+        ...
+
+
+@runtime_checkable
+class FiniteRankedFormat(RankedFormat[Covertext], Protocol[Covertext]):
+    """A ranked format with an exact finite, contiguous rank space."""
+
+    @property
+    def cardinality(self) -> int:
+        """Number of supported ranks, whose domain is ``range(cardinality)``."""
+
+        ...
+
+
+def _rank_offset(length: int) -> int:
+    """Return the first rank assigned to byte strings of ``length``."""
+
+    return (256 ** length - 1) // 255
+
+
+def _bytes_to_rank(value: bytes) -> int:
+    """Rank byte strings in length-first, then numeric, order."""
+
+    offset = _rank_offset(len(value))
+    return offset + int.from_bytes(value, "big")
+
+
+def _rank_to_bytes(index: int) -> bytes:
+    """Invert :func:`_bytes_to_rank`, preserving leading zero bytes."""
+
+    length = _rank_byte_length(index)
+    offset = _rank_offset(length)
+    return (index - offset).to_bytes(length, "big")
+
+
+def _rank_byte_length(index: int) -> int:
+    """Return the byte-string length represented by a shortlex rank."""
+
+    return ((255 * index + 1).bit_length() - 1) // 8
+
+
+def _frame_rank_limit(frame_length: int) -> int:
+    """Return the exclusive upper rank bound for version-one frames."""
+
+    return _rank_offset(frame_length) + 2 * 256 ** (frame_length - 1)
+
+
+class FTE(Generic[Covertext]):
+    """Encrypt bytes into values supplied by a :class:`RankedFormat`.
+
+    The format is structural: any object with callable ``rank`` and ``unrank``
+    methods works without inheriting from this package or importing it at
+    runtime.
+
+    One complete format value represents one encrypted message. Since an
+    arbitrary value has no generic stream boundary, ``decode`` consumes exactly
+    one value and returns plaintext directly, without a stream remainder.
+    """
+
+    # The outer byte reserves a wire-format version. The shortlex byte ranking
+    # below independently preserves the frame length and leading zero bytes.
+    _FRAME_VERSION = b"\x01"
+    _CIPHERTEXT_EXPANSION = Encrypter._CTXT_EXPANSION
+
+    _DEFAULT_MAX_PLAINTEXT_BYTES = 1 << 20
+    _ENCRYPTER_MAX_PLAINTEXT_BYTES = (1 << 32) - 1
+
+    __slots__ = (
+        "_format",
+        "_encrypter",
+        "_cardinality",
+        "_max_plaintext_bytes",
+        "_max_frame_bytes",
+    )
+
+    def __init__(
+        self,
+        *,
+        format: RankedFormat[Covertext],
+        key: bytes,
+        max_plaintext_bytes: int = _DEFAULT_MAX_PLAINTEXT_BYTES,
+    ) -> None:
+        if isinstance(format, type):
+            raise TypeError("format must be an instance, not a class")
+        if not callable(getattr(format, "rank", None)) or not callable(
+            getattr(format, "unrank", None)
+        ):
+            raise TypeError(
+                "format must provide callable rank() and unrank() methods"
+            )
+        if not isinstance(key, bytes):
+            raise TypeError("key must be bytes")
+        if len(key) != 32:
+            raise ValueError(
+                "Key must be exactly 32 bytes "
+                "(16 for encryption + 16 for MAC)"
+            )
+        if (
+            type(max_plaintext_bytes) is not int
+            or not 0 <= max_plaintext_bytes <= self._ENCRYPTER_MAX_PLAINTEXT_BYTES
+        ):
+            raise ValueError(
+                "max_plaintext_bytes must be an integer between 0 and 2**32 - 1"
+            )
+
+        cardinality = getattr(format, "cardinality", None)
+        if cardinality is not None and (
+            type(cardinality) is not int or cardinality <= 0
+        ):
+            raise FormatContractError(
+                "format.cardinality must be a positive integer when provided"
+            )
+
+        self._format = format
+        self._encrypter = Encrypter(key[:16], key[16:])
+        self._cardinality = cardinality
+        self._max_plaintext_bytes = max_plaintext_bytes
+        self._max_frame_bytes = (
+            max_plaintext_bytes + 1 + self._CIPHERTEXT_EXPANSION
+        )
+
+    @property
+    def format(self) -> RankedFormat[Covertext]:
+        """The ranked format used for covertext values."""
+
+        return self._format
+
+    @property
+    def max_plaintext_bytes(self) -> int:
+        """Configured resource ceiling; format capacity may impose a lower one."""
+
+        return self._max_plaintext_bytes
+
+    def encode(self, plaintext: bytes, /) -> Covertext:
+        """Encrypt ``plaintext`` and unrank it into the configured format."""
+
+        if not isinstance(plaintext, bytes):
+            raise TypeError("plaintext must be bytes")
+        if len(plaintext) > self._max_plaintext_bytes:
+            raise MessageTooLargeError(
+                "plaintext exceeds the configured max_plaintext_bytes"
+            )
+
+        frame_length = len(plaintext) + 1 + self._CIPHERTEXT_EXPANSION
+        if (
+            self._cardinality is not None
+            and self._cardinality < _frame_rank_limit(frame_length)
+        ):
+            raise FormatCapacityError(
+                "format cannot represent every encrypted payload at this length"
+            )
+
+        ciphertext = self._encrypter.encrypt(plaintext)
+        framed = self._FRAME_VERSION + ciphertext
+        index = _bytes_to_rank(framed)
+        try:
+            return self._format.unrank(index)
+        except Exception as exc:
+            raise FormatCapacityError(
+                "format cannot represent the encrypted payload rank"
+            ) from exc
+
+    def decode(self, covertext: Covertext, /) -> bytes:
+        """Rank one complete format value and decrypt its plaintext."""
+
+        try:
+            index = self._format.rank(covertext)
+        except Exception as exc:
+            raise InvalidCovertextError("invalid covertext") from exc
+
+        if type(index) is not int or index < 0:
+            raise FormatContractError(
+                "format.rank() must return a non-negative integer"
+            )
+        if self._cardinality is not None and index >= self._cardinality:
+            raise InvalidCovertextError("invalid covertext")
+        if index.bit_length() > 8 * self._max_frame_bytes + 1:
+            raise InvalidCovertextError("invalid covertext")
+        if _rank_byte_length(index) > self._max_frame_bytes:
+            raise InvalidCovertextError("invalid covertext")
+
+        framed = _rank_to_bytes(index)
+        if not framed.startswith(self._FRAME_VERSION) or len(framed) < (
+            len(self._FRAME_VERSION) + self._CIPHERTEXT_EXPANSION
+        ):
+            raise InvalidCovertextError("invalid covertext")
+
+        ciphertext = framed[len(self._FRAME_VERSION):]
+        try:
+            if self._encrypter.getCiphertextLen(ciphertext) != len(ciphertext):
+                raise InvalidCovertextError("invalid covertext")
+            return self._encrypter.decrypt(ciphertext)
+        except InvalidCovertextError:
+            raise
+        except (
+            CiphertextTypeError,
+            RecoverableDecryptionError,
+            UnrecoverableDecryptionError,
+        ) as exc:
+            raise InvalidCovertextError("invalid covertext") from exc

--- a/fte/py.typed
+++ b/fte/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/fte/tests/test_format.py
+++ b/fte/tests/test_format.py
@@ -1,0 +1,252 @@
+"""Tests for the ranked-format API."""
+
+import os
+import unittest
+
+import fte
+from fte.format import (
+    _bytes_to_rank,
+    _frame_rank_limit,
+    _rank_offset,
+    _rank_to_bytes,
+)
+
+
+KEY = bytes(range(32))
+
+
+class HexFormat:
+    """A tiny dependency-free ranked string format for unit tests."""
+
+    def rank(self, value: str) -> int:
+        return int(value, 16)
+
+    def unrank(self, index: int) -> str:
+        return format(index, "x")
+
+
+class Tests(unittest.TestCase):
+    def test_structural_format_conformance(self):
+        self.assertIsInstance(HexFormat(), fte.RankedFormat)
+
+        class FiniteHex(HexFormat):
+            cardinality = 256
+
+        self.assertIsInstance(FiniteHex(), fte.FiniteRankedFormat)
+
+    def test_roundtrip(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY)
+
+        for plaintext in (b"", b"x", b"hello", b"embedded\x00zero"):
+            covertext = encoder.encode(plaintext)
+            self.assertIsInstance(covertext, str)
+            self.assertEqual(encoder.decode(covertext), plaintext)
+
+    def test_shortlex_byte_ranking_preserves_length_and_zeroes(self):
+        values = (
+            b"",
+            b"\x00",
+            b"\x00\x00",
+            b"\x00\x01",
+            b"\xff",
+            bytes(range(256)),
+        )
+
+        ranks = [_bytes_to_rank(value) for value in values]
+
+        self.assertEqual(len(set(ranks)), len(values))
+        for value, rank in zip(values, ranks):
+            self.assertEqual(_rank_to_bytes(rank), value)
+        for rank in range(10_000):
+            self.assertEqual(_bytes_to_rank(_rank_to_bytes(rank)), rank)
+
+    def test_invalid_plaintext(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY)
+
+        with self.assertRaises(TypeError):
+            encoder.encode("not bytes")
+
+    def test_constructor_validates_format_and_key(self):
+        class NonCallableFormat:
+            rank = 1
+            unrank = 2
+
+        with self.assertRaises(TypeError):
+            fte.FTE(format=object(), key=KEY)
+        with self.assertRaises(TypeError):
+            fte.FTE(format=NonCallableFormat(), key=KEY)
+        with self.assertRaises(TypeError):
+            fte.FTE(format=HexFormat, key=KEY)
+        with self.assertRaises(ValueError):
+            fte.FTE(format=HexFormat(), key=b"short")
+        with self.assertRaises(TypeError):
+            fte.FTE(format=HexFormat(), key="not bytes")
+        with self.assertRaises(ValueError):
+            fte.FTE(format=HexFormat(), key=KEY, max_plaintext_bytes=-1)
+        with self.assertRaises(ValueError):
+            fte.FTE(format=HexFormat(), key=KEY, max_plaintext_bytes=True)
+        with self.assertRaises(ValueError):
+            fte.FTE(
+                format=HexFormat(),
+                key=KEY,
+                max_plaintext_bytes=1 << 32,
+            )
+
+        class InvalidCardinality(HexFormat):
+            cardinality = True
+
+        with self.assertRaises(fte.FormatContractError):
+            fte.FTE(format=InvalidCardinality(), key=KEY)
+
+    def test_plaintext_and_rank_resource_limit(self):
+        encoder = fte.FTE(
+            format=HexFormat(),
+            key=KEY,
+            max_plaintext_bytes=4,
+        )
+
+        self.assertEqual(encoder.max_plaintext_bytes, 4)
+        self.assertEqual(encoder.decode(encoder.encode(b"1234")), b"1234")
+        with self.assertRaises(fte.MessageTooLargeError):
+            encoder.encode(b"12345")
+
+        oversized_rank = _rank_offset(encoder._max_frame_bytes + 1)
+        oversized = encoder.format.unrank(oversized_rank)
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode(oversized)
+
+        excessive_bits = encoder.format.unrank(
+            1 << (8 * encoder._max_frame_bytes + 1)
+        )
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode(excessive_bits)
+
+    def test_frame_preserves_leading_zero_bytes(self):
+        framed = b"\x01\x00\x00" + b"e" * 30
+        self.assertEqual(_rank_to_bytes(_bytes_to_rank(framed)), framed)
+
+    def test_decode_rejects_unframed_rank(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY)
+
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode("02")
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode("01")
+
+        ciphertext = encoder._encrypter.encrypt(b"hello")
+        wrong_version = encoder.format.unrank(
+            _bytes_to_rank(b"\x02" + ciphertext)
+        )
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode(wrong_version)
+
+    def test_decode_rejects_trailing_ciphertext(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY)
+        ciphertext = encoder._encrypter.encrypt(b"hello") + b"trailing"
+        index = _bytes_to_rank(b"\x01" + ciphertext)
+        covertext = encoder.format.unrank(index)
+
+        with self.assertRaises(fte.InvalidCovertextError):
+            encoder.decode(covertext)
+
+    def test_decode_rejects_invalid_rank_type(self):
+        class BadFormat:
+            def rank(self, value):
+                return True
+
+            def unrank(self, index):
+                return "unused"
+
+        encoder = fte.FTE(format=BadFormat(), key=KEY)
+
+        with self.assertRaises(fte.FormatContractError):
+            encoder.decode("anything")
+
+    def test_backend_failures_are_normalized(self):
+        class FullFormat(HexFormat):
+            def unrank(self, index):
+                raise IndexError("full")
+
+        class RejectingFormat(HexFormat):
+            def rank(self, value):
+                raise ValueError("not a member")
+
+        with self.assertRaises(fte.FormatCapacityError) as capacity:
+            fte.FTE(format=FullFormat(), key=KEY).encode(b"hello")
+        self.assertIsInstance(capacity.exception.__cause__, IndexError)
+
+        with self.assertRaises(fte.InvalidCovertextError) as invalid:
+            fte.FTE(format=RejectingFormat(), key=KEY).decode("anything")
+        self.assertIsInstance(invalid.exception.__cause__, ValueError)
+
+    def test_finite_capacity_is_preflighted_at_exact_boundary(self):
+        frame_length = 1 + fte.Encrypter._CTXT_EXPANSION
+        required_cardinality = _frame_rank_limit(frame_length)
+
+        class ExactFiniteHex(HexFormat):
+            cardinality = required_cardinality
+
+        class TooSmallFiniteHex(HexFormat):
+            cardinality = required_cardinality - 1
+
+        exact = fte.FTE(format=ExactFiniteHex(), key=KEY)
+        self.assertEqual(exact.decode(exact.encode(b"")), b"")
+
+        with self.assertRaises(fte.FormatCapacityError):
+            fte.FTE(format=TooSmallFiniteHex(), key=KEY).encode(b"")
+
+        out_of_range = ExactFiniteHex().unrank(required_cardinality)
+        with self.assertRaises(fte.InvalidCovertextError):
+            exact.decode(out_of_range)
+
+    def test_wrong_key_is_invalid_covertext(self):
+        sender = fte.FTE(format=HexFormat(), key=KEY)
+        receiver = fte.FTE(format=HexFormat(), key=bytes(reversed(KEY)))
+
+        with self.assertRaises(fte.InvalidCovertextError):
+            receiver.decode(sender.encode(b"hello"))
+
+    def test_format_property_is_read_only(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY)
+
+        with self.assertRaises(AttributeError):
+            encoder.format = HexFormat()
+
+    def test_roundtrip_over_varied_sizes(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY, max_plaintext_bytes=2048)
+
+        for length in list(range(0, 260)) + [512, 1024, 2048]:
+            plaintext = os.urandom(length)
+            self.assertEqual(encoder.decode(encoder.encode(plaintext)), plaintext)
+
+    def test_cross_endpoint_roundtrip(self):
+        # Two independently constructed instances must interoperate: the wire
+        # format is a contract between separate sender and receiver processes.
+        sender = fte.FTE(format=HexFormat(), key=KEY)
+        receiver = fte.FTE(format=HexFormat(), key=KEY)
+
+        for plaintext in (b"", b"x", b"hello", os.urandom(64)):
+            self.assertEqual(receiver.decode(sender.encode(plaintext)), plaintext)
+
+    def test_max_plaintext_bytes_zero_allows_only_empty(self):
+        encoder = fte.FTE(format=HexFormat(), key=KEY, max_plaintext_bytes=0)
+
+        self.assertEqual(encoder.max_plaintext_bytes, 0)
+        self.assertEqual(encoder.decode(encoder.encode(b"")), b"")
+        with self.assertRaises(fte.MessageTooLargeError):
+            encoder.encode(b"x")
+
+    def test_public_exports(self):
+        self.assertIn("FTE", fte.__all__)
+        self.assertIn("FiniteRankedFormat", fte.__all__)
+        self.assertIn("RankedFormat", fte.__all__)
+        self.assertIn("FormatCapacityError", fte.__all__)
+        self.assertIn("FormatContractError", fte.__all__)
+        self.assertIn("InvalidCovertextError", fte.__all__)
+        self.assertIn("MessageTooLargeError", fte.__all__)
+        self.assertIs(fte.FTE, fte.format.FTE)
+        self.assertIs(fte.RankedFormat, fte.format.RankedFormat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ version = {file = "fte/_version.txt"}
 include = ["fte*"]
 
 [tool.setuptools.package-data]
-fte = ["_version.txt"]
+fte = ["_version.txt", "py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["fte/tests"]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             'pytest-cov',
         ],
     },
-    package_data={'fte': ['_version.txt']},
+    package_data={'fte': ['_version.txt', 'py.typed']},
     test_suite='fte.tests',
     packages=['fte', 'fte.tests'],
     classifiers=[


### PR DESCRIPTION
First of a 4-PR stack that replaces #56.

Adds the generic FTE engine as an **additive, non-breaking** API alongside the existing regex `Encoder` (unchanged here):

- `RankedFormat` / `FiniteRankedFormat` structural protocols (`rank`/`unrank`, optional `cardinality`)
- `FTE[T]` — encryption, authenticated framing, capacity checks, error normalization
- `py.typed` + packaging
- `docs/formats.md`: provider contract, inverse laws, limits, error semantics

Next in the stack: **1b** RegexFormat provider → **2** unify `Encoder` onto the engine → **3** require an explicit key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)