### PR TITLE
Add RegexFormat, the built-in regex RankedFormat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ A finite provider may additionally implement `FiniteRankedFormat` by exposing
 an exact positive `cardinality`; libfte then performs capacity checks before
 encryption.
 
+libfte's built-in regex provider implements the same protocol:
+
+```python
+fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=96)
+encoder = fte.FTE(format=fmt, key=key)
+covertext: bytes = encoder.encode(b"secret")
+```
+
 ### Convenience Functions
 
 ```python

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -94,6 +94,25 @@ why a value was rejected. This is safe under FTE's threat model, where an
 on-path observer sees covertext but has no decode oracle. Do not expose `decode`
 directly as a remote timing oracle to untrusted callers.
 
+## Built-in regex provider
+
+The regex implementation uses exactly the same extension point:
+
+```python
+from fte import FTE, RegexFormat
+
+fmt = RegexFormat(r"^[0-9a-f]+$", length=96)
+encoder = FTE(format=fmt, key=shared_32_byte_key)
+
+covertext: bytes = encoder.encode(b"hello")
+assert encoder.decode(covertext) == b"hello"
+```
+
+`RegexFormat.cardinality` is the exact number of fixed-length values. Encoding
+raises `FormatCapacityError` when that finite rank space cannot contain the
+complete encrypted message. Construction raises `ValueError` if `pattern` is not
+a valid regular expression or has no words of exactly `length` bytes.
+
 ## Provider checklist
 
 - Test both inverse laws at representative and boundary ranks.

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -34,6 +34,7 @@ from fte.format import (
     MessageTooLargeError,
     RankedFormat,
 )
+from fte.regex_format import RegexFormat
 
 __version__ = (Path(__file__).parent / '_version.txt').read_text().strip()
 __author__ = 'Kevin P. Dyer'
@@ -49,6 +50,7 @@ __all__ = [
     'InvalidCovertextError',
     'MessageTooLargeError',
     'RankedFormat',
+    'RegexFormat',
     'DfaEncoder',
     'Encrypter',
     'encode',

--- a/fte/regex_format.py
+++ b/fte/regex_format.py
@@ -1,0 +1,63 @@
+"""Built-in regular-expression implementation of RankedFormat[bytes]."""
+
+from __future__ import annotations
+
+import regex2dfa
+
+from fte.dfa import DFA, LanguageIsEmptySetException
+
+
+__all__ = ["RegexFormat"]
+
+
+class RegexFormat:
+    """A fixed-length byte format compiled from a regular expression."""
+
+    __slots__ = ("pattern", "length", "_dfa", "cardinality")
+
+    def __init__(self, pattern: str, *, length: int) -> None:
+        """Compile ``pattern`` into a fixed-length ranked byte format.
+
+        Args:
+            pattern: A regular expression describing the covertext language.
+            length: The exact byte length of every covertext value.
+
+        Raises:
+            TypeError: If ``pattern`` is not a string.
+            ValueError: If ``length`` is not a positive integer, if ``pattern``
+                is not a valid regular expression, or if the language has no
+                words of exactly ``length`` bytes.
+        """
+        if not isinstance(pattern, str):
+            raise TypeError("pattern must be a string")
+        if isinstance(length, bool) or not isinstance(length, int) or length <= 0:
+            raise ValueError("length must be a positive integer")
+
+        try:
+            dfa_str = regex2dfa.regex2dfa(pattern)
+        except Exception as exc:  # regex2dfa raises its own parser errors
+            raise ValueError(
+                f"invalid regular expression: {pattern!r}"
+            ) from exc
+
+        try:
+            dfa = DFA(dfa_str, length)
+        except LanguageIsEmptySetException as exc:
+            raise ValueError(
+                f"pattern {pattern!r} has no words of length {length}"
+            ) from exc
+
+        self.pattern = pattern
+        self.length = length
+        self._dfa = dfa
+        self.cardinality = self._dfa.num_words_in_language(length, length)
+
+    def rank(self, value: bytes, /) -> int:
+        """Return the lexicographic rank of a canonical fixed-length value."""
+
+        return self._dfa.rank(value)
+
+    def unrank(self, index: int, /) -> bytes:
+        """Return the fixed-length value at ``index``."""
+
+        return self._dfa.unrank(index)

--- a/fte/tests/test_regex_format.py
+++ b/fte/tests/test_regex_format.py
@@ -1,0 +1,77 @@
+"""Tests for the built-in RankedFormat regex provider."""
+
+import os
+import re
+import unittest
+
+import fte
+
+
+KEY = bytes(range(32))
+
+
+class Tests(unittest.TestCase):
+    def test_conforms_and_roundtrips(self):
+        fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=96)
+        encoder = fte.FTE(format=fmt, key=KEY)
+
+        covertext = encoder.encode(b"hello")
+
+        self.assertIsInstance(fmt, fte.RankedFormat)
+        self.assertIsInstance(covertext, bytes)
+        self.assertEqual(len(covertext), 96)
+        self.assertEqual(encoder.decode(covertext), b"hello")
+        self.assertEqual(fmt.cardinality, 16 ** 96)
+
+    def test_insufficient_fixed_length_is_capacity_error(self):
+        encoder = fte.FTE(
+            format=fte.RegexFormat(r"^[0-9a-f]+$", length=8),
+            key=KEY,
+        )
+
+        with self.assertRaises(fte.FormatCapacityError):
+            encoder.encode(b"hello")
+
+    def test_multistate_dfa_roundtrips(self):
+        # ``^(0|1)[a-z]+$`` compiles to a multi-state, non-dense DFA, exercising
+        # the standard Goldberg-Sipser rank/unrank branches that the single
+        # self-looping state of ``^[0-9a-f]+$`` never reaches.
+        pattern = r"^(0|1)[a-z]+$"
+        encoder = fte.FTE(format=fte.RegexFormat(pattern, length=200), key=KEY)
+        matcher = re.compile(pattern.encode())
+
+        for plaintext in (b"", b"x", b"hello world", os.urandom(40)):
+            covertext = encoder.encode(plaintext)
+            self.assertEqual(len(covertext), 200)
+            self.assertIsNotNone(matcher.fullmatch(covertext))
+            self.assertEqual(encoder.decode(covertext), plaintext)
+
+    def test_cross_endpoint_roundtrip(self):
+        sender = fte.FTE(
+            format=fte.RegexFormat(r"^[0-9a-f]+$", length=96), key=KEY
+        )
+        receiver = fte.FTE(
+            format=fte.RegexFormat(r"^[0-9a-f]+$", length=96), key=KEY
+        )
+
+        self.assertEqual(receiver.decode(sender.encode(b"hello")), b"hello")
+
+    def test_constructor_validation(self):
+        with self.assertRaises(TypeError):
+            fte.RegexFormat(b"^[0-9a-f]+$", length=96)
+        with self.assertRaises(ValueError):
+            fte.RegexFormat(r"^[0-9a-f]+$", length=0)
+
+    def test_empty_language_is_value_error(self):
+        with self.assertRaises(ValueError):
+            fte.RegexFormat(r"^(ab)+$", length=5)  # no words of odd length
+        with self.assertRaises(ValueError):
+            fte.RegexFormat(r"^abc$", length=2)  # literal longer than length
+
+    def test_invalid_pattern_is_value_error(self):
+        with self.assertRaises(ValueError):
+            fte.RegexFormat(r"^(ab", length=4)  # unbalanced parenthesis
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR 2 of 4 (stacked on #57).

Adds `fte.RegexFormat` — the built-in regex provider that compiles a pattern (via regex2dfa) into a fixed-length byte format implementing `RankedFormat`, so regex covertext flows through the same `FTE` engine. Construction raises a clear `ValueError` for an invalid pattern or an empty `(pattern, length)` language. Still additive: the old `Encoder` is unchanged.

Base: #57. Next: unify `Encoder` onto the engine, then require an explicit key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)