### PR TITLE
Require an explicit key everywhere

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Smoke test (encode/decode round-trip)
         run: |
-          python -c "import fte; e = fte.Encoder(r'^[a-z]+$', 256); m = b'hello world'; assert e.decode(e.encode(m))[0] == m; print('ok')"
+          python -c "import os, fte; e = fte.Encoder(r'^[a-z]+$', 256, key=os.urandom(32)); m = b'hello world'; assert e.decode(e.encode(m))[0] == m; print('ok')"
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/README.md
+++ b/README.md
@@ -35,60 +35,54 @@ Works out of the box with pure Python—no compilation required.
 
 ## Quick Example
 
-Encrypt a secret message so the ciphertext looks like words:
+Encrypt a secret so the ciphertext looks like words:
 
 ```python
+import os
 import fte
 
-# Create encoder: output will be lowercase "words" with spaces
-encoder = fte.Encoder(regex=r'^([a-z]+ )+[a-z]+$', fixed_slice=80)
+key = os.urandom(32)  # 32-byte key, shared by both endpoints
+encoder = fte.Encoder(regex=r'^([a-z]+ )+[a-z]+$', fixed_slice=80, key=key)
 
-# Encrypt
 ciphertext = encoder.encode(b'Attack at dawn')
 print(ciphertext.decode())
 # → "kqpvx mzbjw tnrdc fyhls wqaem xocgi znvub pdkry lfstj bhwce"
 
-# Decrypt
 plaintext, _ = encoder.decode(ciphertext)
 # → b'Attack at dawn'
 ```
 
-The ciphertext looks like random text, but contains your encrypted message.
+The ciphertext looks like random text but contains your encrypted message.
 
 ## More Examples
 
-### URL Paths
-Make ciphertext look like website URLs:
+The snippets below reuse a shared 32-byte `key = os.urandom(32)`.
 
+### URL paths
 ```python
-encoder = fte.Encoder(regex=r'^/[a-z]+/[a-z]+\.html$', fixed_slice=96)
-ciphertext = encoder.encode(b'secret')
+encoder = fte.Encoder(regex=r'^/[a-z]+/[a-z]+\.html$', fixed_slice=96, key=key)
+encoder.encode(b'secret')
 # → "/hsdxanghqvdhb/pvzvdsrpnjktdhnewdfhehaftajibecrluewdyrbe...html"
 ```
 
-### URL Slugs
-Make ciphertext look like hyphenated slugs:
-
+### URL slugs
 ```python
-encoder = fte.Encoder(regex=r'^[a-z]+-[a-z]+-[a-z]+$', fixed_slice=80)
-ciphertext = encoder.encode(b'secret')
+encoder = fte.Encoder(regex=r'^[a-z]+-[a-z]+-[a-z]+$', fixed_slice=80, key=key)
+encoder.encode(b'secret')
 # → "dxosmywnpyjuarsfvcado-osmdsyvovfnnsgzhzelpujnya-qfwbekwh..."
 ```
 
-### Alphanumeric Tokens
-Make ciphertext look like API keys or session tokens:
-
+### Alphanumeric tokens
 ```python
-encoder = fte.Encoder(regex='^[A-Za-z0-9]+$', fixed_slice=64)
-ciphertext = encoder.encode(b'secret')
+encoder = fte.Encoder(regex='^[A-Za-z0-9]+$', fixed_slice=64, key=key)
+encoder.encode(b'secret')
 # → "Kj8mNp2xQw4yLr9vBn3cHt6sFg0dAe5iUo7lMz1bXk..."
 ```
 
-### One-liner Convenience Functions
-
+### One-liner convenience functions
 ```python
-ciphertext = fte.encode(b'secret', regex='^[a-z]+$', fixed_slice=128)
-plaintext, _ = fte.decode(ciphertext, regex='^[a-z]+$', fixed_slice=128)
+ciphertext = fte.encode(b'secret', regex='^[a-z]+$', fixed_slice=128, key=key)
+plaintext, _ = fte.decode(ciphertext, regex='^[a-z]+$', fixed_slice=128, key=key)
 ```
 
 ### Ranked-Format Providers
@@ -144,14 +138,14 @@ See the [`examples/`](examples/) directory for more use cases.
 A regex convenience wrapper over [`fte.FTE`](#ftefte) + `fte.RegexFormat` — the same engine, fully interoperable. Use it for the classic `(regex, fixed_slice)` ergonomics and stream-style `(plaintext, remainder)` decoding.
 
 ```python
-fte.Encoder(regex: str, fixed_slice: int, key: bytes = None)
+fte.Encoder(regex: str, fixed_slice: int, key: bytes)
 ```
 
 | Parameter | Description |
 |-----------|-------------|
 | `regex` | Regular expression defining output format |
-| `fixed_slice` | Length of formatted output |
-| `key` | Optional 32-byte key (random if not provided) |
+| `fixed_slice` | Byte length of formatted output |
+| `key` | 32-byte key (16 encryption + 16 MAC), required |
 
 **Methods:**
 
@@ -208,15 +202,20 @@ covertext: bytes = encoder.encode(b"secret")
 ### Convenience Functions
 
 ```python
-fte.encode(plaintext, regex='^[a-z]+$', fixed_slice=256, key=None)
-fte.decode(ciphertext, regex='^[a-z]+$', fixed_slice=256, key=None)
+fte.encode(plaintext, regex='^[a-z]+$', fixed_slice=256, *, key)
+fte.decode(ciphertext, regex='^[a-z]+$', fixed_slice=256, *, key)
 ```
 
 ## How It Works
 
 1. **Encryption**: Your plaintext is encrypted with AES-CTR and authenticated with HMAC-SHA512
-2. **Ranking**: The ciphertext (an integer) is converted to a string in the regular language using a DFA ranking algorithm
-3. **Output**: The result is a string matching your regex that encodes your encrypted data
+2. **Framing**: The ciphertext is mapped reversibly to a non-negative integer
+3. **Formatting**: A built-in or custom ranked format maps that integer to covertext
+
+The generic API uses variable-length framing. Anyone who can rank a covertext
+can infer its exact plaintext byte length, even without the key. It guarantees
+membership in the selected format, not a uniform distribution over every rank
+when the provider offers more capacity than the message needs.
 
 The capacity depends on your regex—more symbols means more bits per character:
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -30,17 +30,16 @@ Works out of the box with pure Python—no compilation required.
 Encrypt a secret so the ciphertext looks like words:
 
 ```python
+import os
 import fte
 
-# Create encoder: output will be lowercase "words" with spaces
-encoder = fte.Encoder(regex=r'^([a-z]+ )+[a-z]+$', fixed_slice=80)
+key = os.urandom(32)  # 32-byte key, shared by both endpoints
+encoder = fte.Encoder(regex=r'^([a-z]+ )+[a-z]+$', fixed_slice=80, key=key)
 
-# Encrypt
 ciphertext = encoder.encode(b'Attack at dawn')
 print(ciphertext.decode())
 # → "kqpvx mzbjw tnrdc fyhls wqaem xocgi znvub pdkry lfstj bhwce"
 
-# Decrypt
 plaintext, _ = encoder.decode(ciphertext)
 # → b'Attack at dawn'
 ```

--- a/benchmark.py
+++ b/benchmark.py
@@ -53,6 +53,9 @@ SLICE_SWEEP_VALUES = [128, 256, 512, 1024, 2048]
 # with fixed_slice (the output length), not with the plaintext size.
 SAMPLE_PAYLOAD = b"benchmark payload."
 
+# Fixed key -- its value does not affect timing.
+BENCH_KEY = bytes(range(32))
+
 
 # --------------------------------------------------------------------------- #
 # Hardware / environment detection                                            #
@@ -114,7 +117,7 @@ def _bench_build(regex, fixed_slice, iterations):
     """Median time to construct an Encoder (regex -> DFA -> counting table)."""
     def build():
         _clear_encoder_cache()
-        fte.Encoder(regex=regex, fixed_slice=fixed_slice)
+        fte.Encoder(regex=regex, fixed_slice=fixed_slice, key=BENCH_KEY)
     return _median_ms(build, iterations)
 
 
@@ -122,7 +125,7 @@ def _bench_format(label, regex, fixed_slice, payload, iterations, warmup):
     """Benchmark one encoder: build, encode, decode, and verify the round-trip."""
     build_ms = _bench_build(regex, fixed_slice, max(3, iterations // 5))
 
-    encoder = fte.Encoder(regex=regex, fixed_slice=fixed_slice)
+    encoder = fte.Encoder(regex=regex, fixed_slice=fixed_slice, key=BENCH_KEY)
 
     # Correctness: the whole benchmark is meaningless if the round-trip is wrong.
     recovered, _ = encoder.decode(encoder.encode(payload))

--- a/examples/01_basic_usage.py
+++ b/examples/01_basic_usage.py
@@ -6,12 +6,14 @@ This example demonstrates the simplest way to use FTE -
 encoding and decoding a message with a regex format.
 """
 
+import os
+
 import fte
 
 
 def main():
-    # Create an encoder with a regex and output length
-    encoder = fte.Encoder(regex='^(a|b)+$', fixed_slice=512)
+    # Create an encoder with a regex, output length, and a 32-byte key.
+    encoder = fte.Encoder(regex='^(a|b)+$', fixed_slice=512, key=os.urandom(32))
     
     # Encode a message
     plaintext = b'Hello, World!'

--- a/examples/03_hex_format.py
+++ b/examples/03_hex_format.py
@@ -6,12 +6,14 @@ This example shows how to make ciphertext look like hex data,
 which might blend in with log files or debugging output.
 """
 
+import os
+
 import fte
 
 
 def main():
     # Create encoder for hex output
-    encoder = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=128)
+    encoder = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=128, key=os.urandom(32))
     
     plaintext = b'Secret message'
     ciphertext = encoder.encode(plaintext)

--- a/examples/04_alphanumeric_format.py
+++ b/examples/04_alphanumeric_format.py
@@ -6,12 +6,14 @@ This example creates ciphertext that looks like random IDs,
 session tokens, or API keys.
 """
 
+import os
+
 import fte
 
 
 def main():
     # Alphanumeric format (like base62)
-    encoder = fte.Encoder(regex='^[A-Za-z0-9]+$', fixed_slice=64)
+    encoder = fte.Encoder(regex='^[A-Za-z0-9]+$', fixed_slice=64, key=os.urandom(32))
     
     plaintext = b'Sensitive data'
     ciphertext = encoder.encode(plaintext)

--- a/examples/05_word_based_format.py
+++ b/examples/05_word_based_format.py
@@ -6,6 +6,8 @@ This example creates ciphertext that looks like pronounceable
 words or names, useful for human-readable encoded data.
 """
 
+import os
+
 import fte
 
 
@@ -14,8 +16,8 @@ def main():
     consonants = 'bcdfghjklmnpqrstvwxyz'
     vowels = 'aeiou'
     regex = f'^([{consonants}][{vowels}])+$'
-    
-    encoder = fte.Encoder(regex=regex, fixed_slice=128)
+
+    encoder = fte.Encoder(regex=regex, fixed_slice=128, key=os.urandom(32))
     
     plaintext = b'Hidden'
     ciphertext = encoder.encode(plaintext)

--- a/examples/06_capacity_calculation.py
+++ b/examples/06_capacity_calculation.py
@@ -7,12 +7,14 @@ how much data can be encoded, and how to choose parameters.
 """
 
 import math
+import os
+
 import fte
 
 
 def analyze_language(name, regex, fixed_slice):
     """Analyze a language's encoding capacity."""
-    encoder = fte.Encoder(regex=regex, fixed_slice=fixed_slice)
+    encoder = fte.Encoder(regex=regex, fixed_slice=fixed_slice, key=os.urandom(32))
     
     capacity_bits = encoder.capacity
     capacity_bytes = capacity_bits // 8
@@ -64,8 +66,8 @@ def main():
         ("Hex format", "^[0-9a-f]+$", 512),
         ("Alphanumeric", "^[A-Za-z0-9]+$", 256),
     ]:
-        encoder = fte.Encoder(regex=regex, fixed_slice=length)
-        
+        encoder = fte.Encoder(regex=regex, fixed_slice=length, key=os.urandom(32))
+
         try:
             ciphertext = encoder.encode(test_data)
             print(f"\n{name} (length={length}):")

--- a/examples/10_error_handling.py
+++ b/examples/10_error_handling.py
@@ -6,13 +6,16 @@ Shows the exceptions the regex Encoder and the FTE engine raise, and how to
 handle each one.
 """
 
+import os
+
 import fte
 
 
 def main():
     print("=== Error Handling ===\n")
 
-    encoder = fte.Encoder(regex='^[a-z]+$', fixed_slice=128)
+    key = os.urandom(32)
+    encoder = fte.Encoder(regex='^[a-z]+$', fixed_slice=128, key=key)
 
     # 1. Invalid input type
     print("1. Invalid input type:")
@@ -45,7 +48,7 @@ def main():
     # 5. Message too large for the fixed-length format
     print("\n5. Insufficient capacity:")
     try:
-        tiny = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=8)
+        tiny = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=8, key=key)
         tiny.encode(b'x' * 100)
     except fte.FormatCapacityError as e:
         print(f"   Caught FormatCapacityError: {e}")
@@ -53,7 +56,7 @@ def main():
     # 6. Regex with no words of the requested length
     print("\n6. Empty language for (pattern, length):")
     try:
-        fte.Encoder(regex='^(ab)+$', fixed_slice=5)
+        fte.Encoder(regex='^(ab)+$', fixed_slice=5, key=key)
     except ValueError as e:
         print(f"   Caught ValueError: {e}")
 

--- a/examples/11_multiple_messages.py
+++ b/examples/11_multiple_messages.py
@@ -6,13 +6,15 @@ This example shows how to encode and decode multiple messages
 in sequence, demonstrating the remainder handling.
 """
 
+import os
+
 import fte
 
 
 def main():
     print("=== Multiple Messages ===\n")
-    
-    encoder = fte.Encoder(regex='^[a-z]+$', fixed_slice=128)
+
+    encoder = fte.Encoder(regex='^[a-z]+$', fixed_slice=128, key=os.urandom(32))
     
     # Encode multiple messages
     messages = [

--- a/examples/12_convenience_functions.py
+++ b/examples/12_convenience_functions.py
@@ -6,26 +6,29 @@ This example shows the simplest possible API using the
 module-level encode/decode functions.
 """
 
+import os
+
 import fte
 
 
 def main():
     print("=== Convenience Functions ===\n")
-    
+
     plaintext = b'Quick and easy!'
-    
-    # One-liner encode/decode with defaults
+    key = os.urandom(32)
+
+    # One-liner encode/decode with defaults (key is always required)
     print("1. Using defaults (lowercase, length 256):")
-    ciphertext = fte.encode(plaintext)
-    recovered, _ = fte.decode(ciphertext)
+    ciphertext = fte.encode(plaintext, key=key)
+    recovered, _ = fte.decode(ciphertext, key=key)
     print(f"   Plaintext: {plaintext}")
     print(f"   Ciphertext: {ciphertext[:40].decode()}...")
     print(f"   Recovered: {recovered}")
-    
+
     # Custom format
     print("\n2. Custom hex format:")
-    ciphertext = fte.encode(plaintext, regex='^[0-9a-f]+$', fixed_slice=128)
-    recovered, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$', fixed_slice=128)
+    ciphertext = fte.encode(plaintext, regex='^[0-9a-f]+$', fixed_slice=128, key=key)
+    recovered, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$', fixed_slice=128, key=key)
     print(f"   Ciphertext: {ciphertext.decode()}")
     print(f"   Recovered: {recovered}")
     

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,25 +31,25 @@ python examples/01_basic_usage.py
 ## Quick Start
 
 ```python
+import os
 import fte
 
-# Create an encoder
-encoder = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=128)
+key = os.urandom(32)  # 32-byte key, shared by both endpoints
+encoder = fte.Encoder(regex='^[0-9a-f]+$', fixed_slice=128, key=key)
 
-# Encode
 ciphertext = encoder.encode(b'secret message')
-
-# Decode
 plaintext, _ = encoder.decode(ciphertext)
 ```
 
 Or use convenience functions:
 
 ```python
+import os
 import fte
 
-ciphertext = fte.encode(b'secret', regex='^[0-9a-f]+$')
-plaintext, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$')
+key = os.urandom(32)
+ciphertext = fte.encode(b'secret', regex='^[0-9a-f]+$', key=key)
+plaintext, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$', key=key)
 ```
 
 ## Choosing a Format

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -18,7 +18,7 @@ Example usage:
     >>> assert encoder.decode(covertext) == b'secret message'
     >>>
     >>> # fte.Encoder is a regex convenience wrapper over the same engine:
-    >>> regex_encoder = fte.Encoder('^[a-z]+$', 128)
+    >>> regex_encoder = fte.Encoder('^[a-z]+$', 128, key=bytes(range(32)))
     >>> ciphertext = regex_encoder.encode(b'secret message')
     >>> plaintext, _ = regex_encoder.decode(ciphertext)
 
@@ -27,9 +27,8 @@ Encryption" for details: https://kpdyer.com/publications/ccs2013-fte.pdf
 """
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Tuple
 
-from fte.bit_ops import random_bytes
 from fte.encoder import DecodeFailureError, InvalidInputException
 from fte.encrypter import Encrypter
 from fte.format import (
@@ -86,11 +85,11 @@ class Encoder:
         regex: A regular expression defining the output format.
             Examples: '^[a-z]+$', '^[0-9a-f]+$', '^[A-Za-z0-9]+$'
         fixed_slice: The exact byte length of each formatted covertext.
-        key: Optional 32-byte key (16 bytes encryption + 16 bytes MAC).
-            A random key is generated when omitted.
+        key: The 32-byte key (16 bytes encryption + 16 bytes MAC), shared by
+            both endpoints.
 
     Example:
-        >>> encoder = fte.Encoder('^[0-9a-f]+$', 128)
+        >>> encoder = fte.Encoder('^[0-9a-f]+$', 128, key=bytes(range(32)))
         >>> ciphertext = encoder.encode(b'secret')
         >>> plaintext, _ = encoder.decode(ciphertext)
     """
@@ -99,12 +98,10 @@ class Encoder:
         self,
         regex: str,
         fixed_slice: int,
-        key: Optional[bytes] = None,
+        key: bytes,
     ):
         self.regex = regex
         self.fixed_slice = fixed_slice
-        if key is None:
-            key = random_bytes(32)
         self._format = RegexFormat(regex, length=fixed_slice)
         self._fte = FTE(format=self._format, key=key)
 
@@ -171,7 +168,8 @@ def encode(
     plaintext: bytes,
     regex: str = '^[a-z]+$',
     fixed_slice: int = 256,
-    key: Optional[bytes] = None,
+    *,
+    key: bytes,
 ) -> bytes:
     """Encode plaintext with the regex Encoder (convenience function).
 
@@ -183,13 +181,13 @@ def encode(
         plaintext: The data to encrypt.
         regex: Output format as a regular expression.
         fixed_slice: Length of formatted output.
-        key: Optional 32-byte key.
+        key: The 32-byte key shared by both endpoints.
 
     Returns:
         Ciphertext formatted to match the regex.
 
     Example:
-        >>> ciphertext = fte.encode(b'secret', regex='^[0-9a-f]+$')
+        >>> ciphertext = fte.encode(b'secret', regex='^[0-9a-f]+$', key=key)
     """
     cache_key = (regex, fixed_slice, key)
     if cache_key not in _encoders:
@@ -201,7 +199,8 @@ def decode(
     ciphertext: bytes,
     regex: str = '^[a-z]+$',
     fixed_slice: int = 256,
-    key: Optional[bytes] = None,
+    *,
+    key: bytes,
 ) -> Tuple[bytes, bytes]:
     """Decode ciphertext with the regex Encoder (convenience function).
 
@@ -218,7 +217,7 @@ def decode(
         A tuple of (plaintext, remainder).
 
     Example:
-        >>> plaintext, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$')
+        >>> plaintext, _ = fte.decode(ciphertext, regex='^[0-9a-f]+$', key=key)
     """
     cache_key = (regex, fixed_slice, key)
     if cache_key not in _encoders:


### PR DESCRIPTION
Last of three sequential PRs restoring the intended change to `master` (after #62 and #63). **Breaking: API signature.**

A 32-byte `key` is now required everywhere — no default, no random fallback:
- `fte.Encoder(regex, fixed_slice, key)` — required positional.
- `fte.encode(...)` / `fte.decode(...)` — required keyword-only.
- `fte.FTE` already required it.

Every example, the benchmark, the CI smoke test, and all README/docs snippets pass an explicit key. After this merges, `master` holds the complete change (equivalent to the original #57–#60 stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)