### PR TITLE
Source the scheme max-plaintext limit from Encrypter

### DIFF
--- a/fte/core.py
+++ b/fte/core.py
@@ -132,7 +132,7 @@ class FTE(Generic[Covertext]):
     _CIPHERTEXT_EXPANSION = Encrypter._CTXT_EXPANSION
 
     _DEFAULT_MAX_PLAINTEXT_BYTES = 1 << 20
-    _ENCRYPTER_MAX_PLAINTEXT_BYTES = (1 << 32) - 1
+    _ENCRYPTER_MAX_PLAINTEXT_BYTES = Encrypter._MAX_PLAINTEXT_LENGTH
 
     __slots__ = (
         "_format",


### PR DESCRIPTION
## What

Change `FTE._ENCRYPTER_MAX_PLAINTEXT_BYTES` in `fte/core.py` to reference `Encrypter._MAX_PLAINTEXT_LENGTH` instead of independently hardcoding `(1 << 32) - 1`. The attribute name is unchanged, so all call sites are untouched.

## Why

`fte/encrypter.py:40` defines `_MAX_PLAINTEXT_LENGTH = (1 << 32) - 1` and `fte/core.py:135` duplicated the same literal as `_ENCRYPTER_MAX_PLAINTEXT_BYTES`. Both encode the same wire-format fact (4 usable length-header bytes), and a change to one could silently drift from the other. `core.py` already sources `_CIPHERTEXT_EXPANSION` from `Encrypter._CTXT_EXPANSION` on the adjacent line (`fte/core.py:132`); this mirrors that pattern.

## Verified

- Full suite passes from the branch: `65 passed in 1.38s` (`python -m pytest -q`).
- One-line diff, no behavior change (the resolved value is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
