### PR TITLE
Drop custom pytest collection globs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ fte = ["_version.txt", "py.typed"]
 # shared fte/tests/ package, so discover test_*.py anywhere under fte/.
 [tool.pytest.ini_options]
 testpaths = ["fte"]
-python_files = ["test_*.py"]
-python_classes = ["Tests"]
-python_functions = ["test_*"]
 
 [tool.coverage.run]
 source = ["fte"]


### PR DESCRIPTION
## What

Remove the `python_files`, `python_classes`, and `python_functions` overrides from `[tool.pytest.ini_options]` in `pyproject.toml`, keeping `testpaths` and its comment.

## Why

`python_classes = ["Tests"]` (pyproject.toml:64 on master) would silently skip a conventional plain pytest class named `Test*` added by a contributor. The current suite only passes because `unittest.TestCase` subclasses are collected regardless of `python_classes`. The pytest defaults already cover everything this repo uses: the `python_files` default includes `test_*.py`, the `python_classes` default `Test*` matches the literal class name `Tests`, and the `python_functions` default `test*` covers `test_*`.

## Verification

With the repo venv, from the branch:

- `pytest --collect-only -q` reports 65 tests collected, exactly matching master.
- Full suite: 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
