### PR TITLE
Import regex2dfa lazily so import fte works without it

### DIFF
--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -34,7 +34,7 @@ from fte.core import (
     InvalidCovertextError,
     MessageTooLargeError,
 )
-from fte.formats import RankedFormat, RegexFormat
+from fte.formats import RankedFormat
 
 __version__ = (Path(__file__).parent / '_version.txt').read_text().strip()
 __author__ = 'Kevin P. Dyer'
@@ -50,3 +50,18 @@ __all__ = [
     'InvalidCovertextError',
     'MessageTooLargeError',
 ]
+
+
+def __getattr__(name):
+    # Import RegexFormat lazily (PEP 562) so that "import fte" does not pull
+    # in the regex2dfa dependency; providers that bring their own format
+    # never need it.
+    if name == 'RegexFormat':
+        from fte.formats import RegexFormat
+
+        return RegexFormat
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)

--- a/fte/formats/__init__.py
+++ b/fte/formats/__init__.py
@@ -13,7 +13,21 @@ subpackage to copy for a new format.
 """
 
 from fte.formats.base import RankedFormat
-from fte.formats.regex import RegexFormat
 
 
 __all__ = ["RankedFormat", "RegexFormat"]
+
+
+def __getattr__(name):
+    # Import RegexFormat lazily (PEP 562) so that "import fte" does not pull
+    # in the regex2dfa dependency; providers that bring their own format
+    # never need it.
+    if name == "RegexFormat":
+        from fte.formats.regex import RegexFormat
+
+        return RegexFormat
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)

--- a/fte/tests/test_lazy_import.py
+++ b/fte/tests/test_lazy_import.py
@@ -1,0 +1,71 @@
+"""Tests for the lazy import of the regex2dfa-backed RegexFormat."""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Runs in a child interpreter with regex2dfa blocked: sys.modules[name] = None
+# makes any "import regex2dfa" raise ImportError, simulating an environment
+# where regex2dfa is not installed.
+CHILD_SCRIPT = """
+import sys
+
+sys.modules['regex2dfa'] = None
+
+import fte
+
+assert issubclass(fte.FTE, object)
+assert isinstance(fte.RankedFormat, type)
+
+
+class HexFormat:
+    def rank(self, value: str) -> int:
+        return int(value, 16)
+
+    def unrank(self, index: int) -> str:
+        return format(index, "x")
+
+
+cipher = fte.FTE(format=HexFormat(), key=bytes(range(32)))
+assert cipher.decrypt(cipher.encrypt(b"hello")) == b"hello"
+
+try:
+    fte.RegexFormat
+except ImportError:
+    pass
+else:
+    raise AssertionError("accessing fte.RegexFormat should raise ImportError")
+"""
+
+
+class Tests(unittest.TestCase):
+    def test_import_fte_without_regex2dfa(self):
+        result = subprocess.run(
+            [sys.executable, "-c", CHILD_SCRIPT],
+            env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_regex_format_still_importable(self):
+        import fte
+        from fte.formats import RegexFormat
+
+        self.assertIs(fte.RegexFormat, RegexFormat)
+
+    def test_dir_lists_regex_format(self):
+        import fte
+        import fte.formats
+
+        self.assertIn("RegexFormat", dir(fte))
+        self.assertIn("RegexFormat", dir(fte.formats))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Defer the import of `regex2dfa` using PEP 562 module `__getattr__` so that `import fte` succeeds even when regex2dfa is not installed. `fte.RegexFormat` (and `fte.formats.RegexFormat`) now import `regex2dfa` only on first access; `RankedFormat` and the rest of the public API stay eager. `__all__` is unchanged in both modules and `__dir__` keeps introspection intact.

## Why

`import fte` eagerly pulled in regex2dfa via the chain `fte/__init__.py` -> `fte/formats/__init__.py` -> `fte/formats/regex/__init__.py` -> `format.py` (`import regex2dfa`). That contradicts the structural bring-your-own-format contract: `fte/core.py` explicitly supports `RankedFormat` providers that never import this package, yet the library could not even be imported when regex2dfa was absent.

Note: regex2dfa 0.2.x is a pure-Python package (an earlier revision of this PR called it a C extension, which is wrong; the original 2013 regex2dfa wrapped C++, the current PyPI package does not). The isolation rationale is unchanged: providers that bring their own format never need the dependency, and `import fte` gets lighter.

## Verification

- New `fte/tests/test_lazy_import.py`: a subprocess test blocks regex2dfa (`sys.modules["regex2dfa"] = None`), then asserts `import fte` succeeds, `fte.FTE` and `fte.RankedFormat` are usable, and accessing `fte.RegexFormat` raises ImportError. Normal-path tests assert `fte.RegexFormat` and `from fte.formats import RegexFormat` still work.
- Full suite passes: 68 passed (65 on master plus 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
