### PR TITLE
Split AT&T FST parsing from the DFA ranker

### DIFF
--- a/fte/formats/regex/dfa.py
+++ b/fte/formats/regex/dfa.py
@@ -10,7 +10,16 @@ The algorithm is based on:
 - "Protocol Misidentification Made Easy with Format-Transforming Encryption"
 """
 
-from typing import Dict, List, Set
+from typing import Dict, FrozenSet, List, NamedTuple, Set, Tuple, Union
+
+__all__ = [
+    "DFA",
+    "ParsedFst",
+    "parse_att_fst",
+    "InvalidFSTFormat",
+    "InvalidRankInput",
+    "InvalidUnrankInput",
+]
 
 
 class InvalidFSTFormat(Exception):
@@ -25,87 +34,140 @@ class InvalidUnrankInput(Exception):
     """Raised when a rank is outside the valid range."""
 
 
-class DFA:
-    """Rank and unrank the words of a regular language by length.
+class ParsedFst(NamedTuple):
+    """A parsed automaton: the DFA structure without any ranking tables.
 
-    Parses a minimized AT&T FST and builds the Goldberg-Sipser counting table up
-    to a maximum ``length``. :meth:`rank` and :meth:`unrank` then map between a
-    word and its lexicographic index among the accepted words of that word's
-    length, and :meth:`num_words` counts the accepted words of one length.
-    Whether any words exist at the lengths the caller cares about is the
-    caller's concern.
+    Attributes:
+        start_state: The automaton's start state.
+        final_states: The accepting states.
+        transitions: (src_state, dst_state, symbol) triples.
+        symbols: The alphabet, in lexicographic (ranking) order.
+    """
+
+    start_state: int
+    final_states: FrozenSet[int]
+    transitions: Tuple[Tuple[int, int, int], ...]
+    symbols: Tuple[int, ...]
+
+
+def parse_att_fst(dfa_str: str) -> ParsedFst:
+    """Parse a minimized AT&T FST formatted DFA string.
 
     Args:
         dfa_str: A minimized AT&T FST formatted DFA string.
+
+    Returns:
+        The parsed automaton as a :class:`ParsedFst`.
+
+    Raises:
+        InvalidFSTFormat: If the input has a line that is neither a transition
+            nor a final state, no states, no symbols, or states not numbered
+            densely from zero.
+    """
+    states_set: Set[int] = set()
+    symbols_set: Set[int] = set()
+    final_states: Set[int] = set()
+    transitions: List[Tuple[int, int, int]] = []
+    start_state = 0
+    start_state_set = False
+
+    for line in dfa_str.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split('\t')
+
+        if len(parts) == 4:
+            # Transition: src_state, dst_state, input_symbol, output_symbol
+            src = int(parts[0])
+            dst = int(parts[1])
+            symbol = int(parts[2])
+
+            states_set.add(src)
+            states_set.add(dst)
+            symbols_set.add(symbol)
+            transitions.append((src, dst, symbol))
+
+            if not start_state_set:
+                start_state = src
+                start_state_set = True
+
+        elif len(parts) == 1:
+            # Final state
+            final = int(parts[0])
+            final_states.add(final)
+            states_set.add(final)
+        elif len(parts) > 1:
+            raise InvalidFSTFormat("Invalid FST format")
+
+    if not states_set:
+        raise InvalidFSTFormat("DFA has no states")
+    if not symbols_set:
+        raise InvalidFSTFormat("DFA has no symbols")
+
+    # Sort for consistent ordering. The transition table is indexed by raw
+    # state id, so states must be numbered densely from zero.
+    states = sorted(states_set)
+    if states != list(range(len(states))):
+        raise InvalidFSTFormat("DFA states must be numbered 0..N-1")
+
+    return ParsedFst(
+        start_state=start_state,
+        final_states=frozenset(final_states),
+        transitions=tuple(transitions),
+        symbols=tuple(sorted(symbols_set)),
+    )
+
+
+class DFA:
+    """Rank and unrank the words of a regular language by length.
+
+    Builds the Goldberg-Sipser counting table up to a maximum ``length`` from a
+    minimized AT&T FST string (parsed via :func:`parse_att_fst`) or from a
+    :class:`ParsedFst` supplied directly. :meth:`rank` and :meth:`unrank` then
+    map between a word and its lexicographic index among the accepted words of
+    that word's length, and :meth:`num_words` counts the accepted words of one
+    length. Whether any words exist at the lengths the caller cares about is
+    the caller's concern.
+
+    Args:
+        dfa_str: A minimized AT&T FST formatted DFA string, or a
+            :class:`ParsedFst`.
         length: The maximum word length the counting table supports.
     """
 
-    def __init__(self, dfa_str: str, length: int):
+    def __init__(self, dfa_str: Union[str, ParsedFst], length: int):
         self._length = length
-        self._start_state = 0
+        if isinstance(dfa_str, ParsedFst):
+            parsed = dfa_str
+        else:
+            parsed = parse_att_fst(dfa_str)
+        self._start_state = parsed.start_state
         self._num_states = 0
-        self._symbols: List[int] = []
-        self._final_states: Set[int] = set()
+        self._symbols: List[int] = list(parsed.symbols)
+        self._final_states: Set[int] = set(parsed.final_states)
         self._sigma_reverse: Dict[int, int] = {}  # symbol byte value -> index
         self._delta: List[List[int]] = []         # transition table
         self._delta_dense: List[bool] = []        # all-transitions-equal flag
         self._T: List[List[int]] = []             # counting table
 
-        self._parse_dfa(dfa_str)
+        self._build_delta(parsed.transitions)
         self._build_table()
 
-    def _parse_dfa(self, dfa_str: str) -> None:
-        """Parse the AT&T FST formatted DFA string."""
-        states_set: Set[int] = set()
-        symbols_set: Set[int] = set()
-        transitions: List[tuple] = []
-        start_state_set = False
-
-        for line in dfa_str.split('\n'):
-            line = line.strip()
-            if not line:
-                continue
-
-            parts = line.split('\t')
-
-            if len(parts) == 4:
-                # Transition: src_state, dst_state, input_symbol, output_symbol
-                src = int(parts[0])
-                dst = int(parts[1])
-                symbol = int(parts[2])
-
-                states_set.add(src)
-                states_set.add(dst)
-                symbols_set.add(symbol)
-                transitions.append((src, dst, symbol))
-
-                if not start_state_set:
-                    self._start_state = src
-                    start_state_set = True
-
-            elif len(parts) == 1:
-                # Final state
-                final = int(parts[0])
-                self._final_states.add(final)
-                states_set.add(final)
-            elif len(parts) > 1:
-                raise InvalidFSTFormat("Invalid FST format")
-
-        if not states_set:
-            raise InvalidFSTFormat("DFA has no states")
-        if not symbols_set:
-            raise InvalidFSTFormat("DFA has no symbols")
-
-        # Sort for consistent ordering. The transition table is indexed by raw
-        # state id, so states must be numbered densely from zero.
-        states = sorted(states_set)
-        if states != list(range(len(states))):
-            raise InvalidFSTFormat("DFA states must be numbered 0..N-1")
-        self._symbols = sorted(symbols_set)
-
-        # One extra dead state absorbs missing transitions.
-        dead_state = len(states)
-        self._num_states = len(states) + 1
+    def _build_delta(
+        self, transitions: Tuple[Tuple[int, int, int], ...]
+    ) -> None:
+        """Build the transition table from the parsed transitions."""
+        # One extra dead state absorbs missing transitions. State ids index
+        # the table directly, so the dead state follows the highest real id.
+        max_state = self._start_state
+        for state in self._final_states:
+            max_state = max(max_state, state)
+        for src, dst, _ in transitions:
+            max_state = max(max_state, src, dst)
+        dead_state = max_state + 1
+        self._num_states = dead_state + 1
         num_symbols = len(self._symbols)
 
         self._sigma_reverse = {

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -14,6 +14,8 @@ from fte.formats.regex.dfa import (
     InvalidFSTFormat,
     InvalidRankInput,
     InvalidUnrankInput,
+    ParsedFst,
+    parse_att_fst,
 )
 
 
@@ -78,6 +80,65 @@ class Tests(unittest.TestCase):
             DFA("0", 4)                # a final state but no transitions/symbols
         with self.assertRaises(InvalidFSTFormat):
             DFA("0\t1\t2", 4)          # a 3-field line is neither transition nor final
+
+    def test_parse_att_fst_returns_structure(self):
+        # ``a[ab]*``: state 0 reads an 'a' to reach accepting state 1, which
+        # loops on 'a' and 'b'.
+        parsed = parse_att_fst(
+            "0\t1\t97\t97\n"
+            "1\t1\t98\t98\n"
+            "1\t1\t97\t97\n"
+            "1\n"
+        )
+        self.assertIsInstance(parsed, ParsedFst)
+        self.assertEqual(parsed.start_state, 0)
+        self.assertEqual(parsed.final_states, frozenset({1}))
+        self.assertEqual(
+            parsed.transitions, ((0, 1, 97), (1, 1, 98), (1, 1, 97))
+        )
+        self.assertEqual(parsed.symbols, (97, 98))  # sorted, deduplicated
+
+    def test_parse_att_fst_rejects_no_states(self):
+        with self.assertRaises(InvalidFSTFormat):
+            parse_att_fst("")
+
+    def test_parse_att_fst_rejects_no_symbols(self):
+        # A lone final state gives a state set but no transitions/symbols.
+        with self.assertRaises(InvalidFSTFormat):
+            parse_att_fst("0")
+
+    def test_parse_att_fst_rejects_sparse_state_numbering(self):
+        # States {0, 2} skip 1, so the dense 0..N-1 check fails.
+        with self.assertRaises(InvalidFSTFormat):
+            parse_att_fst("0\t2\t97\t97\n2")
+
+    def test_parse_att_fst_rejects_malformed_line(self):
+        with self.assertRaises(InvalidFSTFormat):
+            parse_att_fst("0\t1\t2")   # 3 fields: neither transition nor final
+
+    def test_dfa_from_hand_built_parsed_fst(self):
+        # Hand-built ``[01]+``: state 0 reads either bit to reach accepting
+        # state 1, which loops on both. No regex2dfa involved.
+        parsed = ParsedFst(
+            start_state=0,
+            final_states=frozenset({1}),
+            transitions=(
+                (0, 1, 0x30), (0, 1, 0x31),
+                (1, 1, 0x30), (1, 1, 0x31),
+            ),
+            symbols=(0x30, 0x31),
+        )
+        dfa = DFA(parsed, 6)
+        self.assertEqual(dfa.num_words(0), 0)
+        for length in range(1, 7):
+            count = dfa.num_words(length)
+            self.assertEqual(count, 2 ** length)
+            for index in (0, count // 2, count - 1):
+                word = dfa.unrank(index, length)
+                self.assertEqual(len(word), length)
+                self.assertEqual(dfa.rank(word), index)
+        self.assertEqual(dfa.unrank(0, 3), b"000")
+        self.assertEqual(dfa.rank(b"111"), 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Splits parsing of the AT&T FST text format out of the DFA ranker in `fte/formats/regex/dfa.py`:

- New module-level `ParsedFst` NamedTuple (`start_state`, `final_states`, `transitions`, `symbols`) and `parse_att_fst(dfa_str) -> ParsedFst` holding all of the parsing logic and `InvalidFSTFormat` validation (malformed lines, no states, no symbols, dense 0..N-1 state numbering).
- `DFA.__init__(dfa_str, length)` keeps its signature: a `str` is parsed exactly as before, and a `ParsedFst` is now accepted directly in place of the string (isinstance check).
- Adds an `__all__` listing `DFA`, `ParsedFst`, `parse_att_fst`, and the three exception classes.

## Why

The private `DFA._parse_dfa` fused format parsing with the Goldberg-Sipser ranking machinery: the parsed automaton could not be built, inspected, or unit-tested without paying for full counting-table construction, and the ranker could not run on a hand-built automaton. With the seam in place, `parse_att_fst` is testable on its own and `DFA` can rank/unrank an automaton constructed without `regex2dfa`.

Behavior on the `str` path is identical. The only structural change to table setup is that the dead state is now derived from the highest real state id (`fte/formats/regex/dfa.py`, `_build_delta`); for parsed input the dense 0..N-1 numbering check guarantees this matches the old `len(states)` value exactly.

## Verified

- Full suite passes from the branch: 71 passed (65 on master plus 6 new) via `PYTHONPATH=$PWD python -m pytest -q`.
- New tests: direct `parse_att_fst` structure test, one test per `InvalidFSTFormat` case, and a rank/unrank round-trip on a hand-built two-state `ParsedFst` over two symbols, proving the seam works without `regex2dfa`.
- `grep -rn "_parse_dfa"` confirms no remaining references to the removed private method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
