### PR TITLE
Extract the version-1 wire frame codec into fte/frame.py

### DIFF
--- a/fte/core.py
+++ b/fte/core.py
@@ -1,15 +1,16 @@
 """The FTE engine: encrypt bytes into values drawn from a ranked format.
 
-This module owns everything cryptographic: authenticated encryption, the
-versioned frame, and the reversible bytes-to-integer mapping. The covertext
-language is supplied from :mod:`fte.formats` as a :class:`RankedFormat`, so the
-engine never needs to know what the output looks like.
+This module owns the engine itself: authenticated encryption wrapped in the
+version-1 wire frame defined by :mod:`fte.frame`. The covertext language is
+supplied from :mod:`fte.formats` as a :class:`RankedFormat`, so the engine
+never needs to know what the output looks like.
 """
 
 from __future__ import annotations
 
 from typing import Generic, TypeVar
 
+from fte import frame
 from fte._encrypter import DecryptionError, Encrypter
 from fte.formats.base import RankedFormat
 
@@ -47,63 +48,6 @@ class InvalidCovertextError(FTEError):
     """Raised when a format value cannot be authenticated and decrypted."""
 
 
-def _rank_offset(length: int) -> int:
-    """Return the first rank assigned to byte strings of ``length``."""
-
-    return (256 ** length - 1) // 255
-
-
-def _bytes_to_rank(value: bytes) -> int:
-    """Rank byte strings in length-first, then numeric, order."""
-
-    offset = _rank_offset(len(value))
-    return offset + int.from_bytes(value, "big")
-
-
-def _rank_to_bytes(index: int) -> bytes:
-    """Invert :func:`_bytes_to_rank`, preserving leading zero bytes."""
-
-    length = _rank_byte_length(index)
-    offset = _rank_offset(length)
-    return (index - offset).to_bytes(length, "big")
-
-
-def _rank_byte_length(index: int) -> int:
-    """Return the byte-string length represented by a shortlex rank."""
-
-    return ((255 * index + 1).bit_length() - 1) // 8
-
-
-def _frame_rank_limit(frame_length: int) -> int:
-    """Return the exclusive upper rank bound for version-one frames."""
-
-    return _rank_offset(frame_length) + 2 * 256 ** (frame_length - 1)
-
-
-def _capacity_plaintext_limit(cardinality: int, expansion: int) -> int:
-    """Largest plaintext length a finite format of ``cardinality`` can hold.
-
-    Returns the greatest plaintext length ``L`` whose encrypted frame the format
-    can still represent, or ``-1`` if it cannot represent even an empty message.
-    This is the exact inverse of the per-length capacity check, so ``L`` bytes
-    fit and ``L + 1`` bytes do not.
-    """
-
-    min_frame = 1 + expansion
-    if cardinality < _frame_rank_limit(min_frame):
-        return -1
-    # _frame_rank_limit(fl) is dominated by 256**fl, so the frame length is
-    # close to log256(cardinality). Estimate it, then correct by a step or two.
-    frame_length = max(min_frame, cardinality.bit_length() // 8)
-    # The estimate is never larger than the true frame length, so in practice
-    # only the upward correction runs; the downward one is a defensive guard.
-    while cardinality < _frame_rank_limit(frame_length):  # pragma: no cover
-        frame_length -= 1
-    while cardinality >= _frame_rank_limit(frame_length + 1):
-        frame_length += 1
-    return frame_length - 1 - expansion
-
-
 class FTE(Generic[Covertext]):
     """Encrypt bytes into values supplied by a :class:`RankedFormat`.
 
@@ -126,9 +70,7 @@ class FTE(Generic[Covertext]):
     the default.
     """
 
-    # The outer byte reserves a wire-format version. The shortlex byte ranking
-    # below independently preserves the frame length and leading zero bytes.
-    _FRAME_VERSION = b"\x01"
+    _FRAME_VERSION = frame.FRAME_VERSION
     _CIPHERTEXT_EXPANSION = Encrypter._CTXT_EXPANSION
 
     _DEFAULT_MAX_PLAINTEXT_BYTES = 1 << 20
@@ -198,7 +140,9 @@ class FTE(Generic[Covertext]):
             effective = resource_max
         else:
             capacity_limit = min(
-                _capacity_plaintext_limit(cardinality, self._CIPHERTEXT_EXPANSION),
+                frame.capacity_plaintext_limit(
+                    cardinality, self._CIPHERTEXT_EXPANSION
+                ),
                 self._ENCRYPTER_MAX_PLAINTEXT_BYTES,
             )
             if capacity_limit < 0:
@@ -239,7 +183,7 @@ class FTE(Generic[Covertext]):
             raise TypeError("plaintext must be bytes")
         # Exceeding the resource ceiling is the caller's own limit; exceeding a
         # finite format's capacity is the format being too small. The capacity
-        # check is the exact inverse of _capacity_plaintext_limit.
+        # check is the exact inverse of frame.capacity_plaintext_limit.
         if len(plaintext) > self._resource_max:
             raise MessageTooLargeError(
                 "plaintext exceeds the configured max_plaintext_bytes"
@@ -254,7 +198,7 @@ class FTE(Generic[Covertext]):
 
         ciphertext = self._encrypter.encrypt(plaintext)
         framed = self._FRAME_VERSION + ciphertext
-        index = _bytes_to_rank(framed)
+        index = frame.bytes_to_rank(framed)
         try:
             return self._format.unrank(index)
         except Exception as exc:
@@ -281,10 +225,10 @@ class FTE(Generic[Covertext]):
             raise InvalidCovertextError("invalid covertext")
         if index.bit_length() > 8 * self._max_frame_bytes + 1:
             raise InvalidCovertextError("invalid covertext")
-        if _rank_byte_length(index) > self._max_frame_bytes:
+        if frame.rank_byte_length(index) > self._max_frame_bytes:
             raise InvalidCovertextError("invalid covertext")
 
-        framed = _rank_to_bytes(index)
+        framed = frame.rank_to_bytes(index)
         if not framed.startswith(self._FRAME_VERSION) or len(framed) < (
             len(self._FRAME_VERSION) + self._CIPHERTEXT_EXPANSION
         ):

--- a/fte/frame.py
+++ b/fte/frame.py
@@ -1,0 +1,82 @@
+"""The version-1 wire frame: shortlex byte-string ranking and capacity math.
+
+This module defines the mapping between encrypted frames and the integer
+ranks a :class:`~fte.formats.base.RankedFormat` consumes, plus the capacity
+math derived from it. Everything here is part of the wire format shared by
+both endpoints, so any change breaks compatibility with existing peers.
+"""
+
+from __future__ import annotations
+
+
+__all__ = [
+    "FRAME_VERSION",
+    "bytes_to_rank",
+    "capacity_plaintext_limit",
+    "frame_rank_limit",
+    "rank_byte_length",
+    "rank_offset",
+    "rank_to_bytes",
+]
+
+
+# The outer byte reserves a wire-format version. The shortlex byte ranking
+# below independently preserves the frame length and leading zero bytes.
+FRAME_VERSION = b"\x01"
+
+
+def rank_offset(length: int) -> int:
+    """Return the first rank assigned to byte strings of ``length``."""
+
+    return (256 ** length - 1) // 255
+
+
+def bytes_to_rank(value: bytes) -> int:
+    """Rank byte strings in length-first, then numeric, order."""
+
+    offset = rank_offset(len(value))
+    return offset + int.from_bytes(value, "big")
+
+
+def rank_to_bytes(index: int) -> bytes:
+    """Invert :func:`bytes_to_rank`, preserving leading zero bytes."""
+
+    length = rank_byte_length(index)
+    offset = rank_offset(length)
+    return (index - offset).to_bytes(length, "big")
+
+
+def rank_byte_length(index: int) -> int:
+    """Return the byte-string length represented by a shortlex rank."""
+
+    return ((255 * index + 1).bit_length() - 1) // 8
+
+
+def frame_rank_limit(frame_length: int) -> int:
+    """Return the exclusive upper rank bound for version-one frames."""
+
+    return rank_offset(frame_length) + 2 * 256 ** (frame_length - 1)
+
+
+def capacity_plaintext_limit(cardinality: int, expansion: int) -> int:
+    """Largest plaintext length a finite format of ``cardinality`` can hold.
+
+    Returns the greatest plaintext length ``L`` whose encrypted frame the format
+    can still represent, or ``-1`` if it cannot represent even an empty message.
+    This is the exact inverse of the per-length capacity check, so ``L`` bytes
+    fit and ``L + 1`` bytes do not.
+    """
+
+    min_frame = 1 + expansion
+    if cardinality < frame_rank_limit(min_frame):
+        return -1
+    # frame_rank_limit(fl) is dominated by 256**fl, so the frame length is
+    # close to log256(cardinality). Estimate it, then correct by a step or two.
+    frame_length = max(min_frame, cardinality.bit_length() // 8)
+    # The estimate is never larger than the true frame length, so in practice
+    # only the upward correction runs; the downward one is a defensive guard.
+    while cardinality < frame_rank_limit(frame_length):  # pragma: no cover
+        frame_length -= 1
+    while cardinality >= frame_rank_limit(frame_length + 1):
+        frame_length += 1
+    return frame_length - 1 - expansion

--- a/fte/tests/test_format.py
+++ b/fte/tests/test_format.py
@@ -4,12 +4,12 @@ import os
 import unittest
 
 import fte
-from fte.core import (
-    _bytes_to_rank,
-    _capacity_plaintext_limit,
-    _frame_rank_limit,
-    _rank_offset,
-    _rank_to_bytes,
+from fte.frame import (
+    bytes_to_rank,
+    capacity_plaintext_limit,
+    frame_rank_limit,
+    rank_offset,
+    rank_to_bytes,
 )
 
 
@@ -48,13 +48,13 @@ class Tests(unittest.TestCase):
             bytes(range(256)),
         )
 
-        ranks = [_bytes_to_rank(value) for value in values]
+        ranks = [bytes_to_rank(value) for value in values]
 
         self.assertEqual(len(set(ranks)), len(values))
         for value, rank in zip(values, ranks):
-            self.assertEqual(_rank_to_bytes(rank), value)
+            self.assertEqual(rank_to_bytes(rank), value)
         for rank in range(10_000):
-            self.assertEqual(_bytes_to_rank(_rank_to_bytes(rank)), rank)
+            self.assertEqual(bytes_to_rank(rank_to_bytes(rank)), rank)
 
     def test_invalid_plaintext(self):
         cipher = fte.FTE(format=HexFormat(), key=KEY)
@@ -106,7 +106,7 @@ class Tests(unittest.TestCase):
         with self.assertRaises(fte.MessageTooLargeError):
             cipher.encrypt(b"12345")
 
-        oversized_rank = _rank_offset(cipher._max_frame_bytes + 1)
+        oversized_rank = rank_offset(cipher._max_frame_bytes + 1)
         oversized = cipher.format.unrank(oversized_rank)
         with self.assertRaises(fte.InvalidCovertextError):
             cipher.decrypt(oversized)
@@ -125,7 +125,7 @@ class Tests(unittest.TestCase):
         limit = cipher.max_plaintext_bytes
         self.assertEqual(
             limit,
-            _capacity_plaintext_limit(
+            capacity_plaintext_limit(
                 fmt.cardinality, fte.FTE._CIPHERTEXT_EXPANSION
             ),
         )
@@ -176,16 +176,16 @@ class Tests(unittest.TestCase):
 
         def brute(cardinality):
             frame = 1 + exp
-            if cardinality < _frame_rank_limit(frame):
+            if cardinality < frame_rank_limit(frame):
                 return -1
-            while cardinality >= _frame_rank_limit(frame + 1):
+            while cardinality >= frame_rank_limit(frame + 1):
                 frame += 1
             return frame - 1 - exp
 
         cardinalities = [
             1,
-            _frame_rank_limit(1 + exp) - 1,
-            _frame_rank_limit(1 + exp),
+            frame_rank_limit(1 + exp) - 1,
+            frame_rank_limit(1 + exp),
             16 ** 8,
             16 ** 65,
             16 ** 96,
@@ -195,12 +195,12 @@ class Tests(unittest.TestCase):
         ]
         for cardinality in cardinalities:
             self.assertEqual(
-                _capacity_plaintext_limit(cardinality, exp), brute(cardinality)
+                capacity_plaintext_limit(cardinality, exp), brute(cardinality)
             )
 
     def test_frame_preserves_leading_zero_bytes(self):
         framed = b"\x01\x00\x00" + b"e" * 30
-        self.assertEqual(_rank_to_bytes(_bytes_to_rank(framed)), framed)
+        self.assertEqual(rank_to_bytes(bytes_to_rank(framed)), framed)
 
     def test_decode_rejects_unframed_rank(self):
         cipher = fte.FTE(format=HexFormat(), key=KEY)
@@ -212,7 +212,7 @@ class Tests(unittest.TestCase):
 
         ciphertext = cipher._encrypter.encrypt(b"hello")
         wrong_version = cipher.format.unrank(
-            _bytes_to_rank(b"\x02" + ciphertext)
+            bytes_to_rank(b"\x02" + ciphertext)
         )
         with self.assertRaises(fte.InvalidCovertextError):
             cipher.decrypt(wrong_version)
@@ -220,7 +220,7 @@ class Tests(unittest.TestCase):
     def test_decode_rejects_trailing_ciphertext(self):
         cipher = fte.FTE(format=HexFormat(), key=KEY)
         ciphertext = cipher._encrypter.encrypt(b"hello") + b"trailing"
-        index = _bytes_to_rank(b"\x01" + ciphertext)
+        index = bytes_to_rank(b"\x01" + ciphertext)
         covertext = cipher.format.unrank(index)
 
         with self.assertRaises(fte.InvalidCovertextError):
@@ -233,7 +233,7 @@ class Tests(unittest.TestCase):
         ciphertext = cipher._encrypter.encrypt(b"hello")
 
         for damaged in (ciphertext[:-1], ciphertext + b"x"):
-            covertext = cipher.format.unrank(_bytes_to_rank(b"\x01" + damaged))
+            covertext = cipher.format.unrank(bytes_to_rank(b"\x01" + damaged))
             with self.assertRaises(fte.InvalidCovertextError) as caught:
                 cipher.decrypt(covertext)
             self.assertEqual(str(caught.exception), "invalid covertext")
@@ -272,7 +272,7 @@ class Tests(unittest.TestCase):
 
     def test_finite_capacity_is_preflighted_at_exact_boundary(self):
         frame_length = 1 + fte.FTE._CIPHERTEXT_EXPANSION
-        required_cardinality = _frame_rank_limit(frame_length)
+        required_cardinality = frame_rank_limit(frame_length)
 
         class ExactFiniteHex(HexFormat):
             cardinality = required_cardinality


### PR DESCRIPTION
## What

Extracts the version-1 wire frame codec out of `fte/core.py` into a new `fte/frame.py`: the shortlex byte-string ranking (`rank_offset`, `bytes_to_rank`, `rank_to_bytes`, `rank_byte_length`), its capacity math (`frame_rank_limit`, `capacity_plaintext_limit`), and a `FRAME_VERSION = b"\x01"` module constant. The names are now public, with an `__all__` and a module docstring stating that everything in the module is part of the wire format, so changes break compatibility. `fte/core.py` imports the codec via `from fte import frame`, and `FTE._FRAME_VERSION` is now `frame.FRAME_VERSION`. The frame names are deliberately not re-exported from `fte/__init__.py`.

## Why

The codec was buried in `fte/core.py` as module privates (`_rank_offset` at core.py:50 through `_capacity_plaintext_limit` at core.py:83 on master), even though it is a pure, self-contained wire-format contract distinct from the engine's key handling and limit enforcement. The tests already treated it as a de facto public surface: `fte/tests/test_format.py:7-13` imported five underscore names from `fte.core` to exercise the ranking and capacity math directly. Giving the codec its own module makes the compatibility boundary explicit and lets the tests import public names.

## Verification

- Full suite passes from the branch: 65 passed in 1.36s (`PYTHONPATH=$PWD .venv python -m pytest -q`).
- No references to the old underscore names remain anywhere in the tree.
- Pure code motion plus renames: function bodies, docstrings, and comments are unchanged apart from updated cross-references.

## Merge order

Please rebase and merge this after fix/decrypt-guard-init-cost, which edits the same region of `fte/core.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
