### PR TITLE
Ship the docs in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
 include BUILDING.md
+include README_PYPI.md
+include LICENSE
+include SECURITY.md
+include docs/formats.md
+recursive-include fte *.md
 graft tests
 prune tests/__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ version = {file = "fte/_version.txt"}
 include = ["fte*"]
 
 [tool.setuptools.package-data]
-fte = ["_version.txt", "py.typed"]
+fte = ["_version.txt", "py.typed", "formats/regex/README.md"]
 
 # All tests live in the top-level tests/ directory.
 [tool.pytest.ini_options]


### PR DESCRIPTION
## What

Expand MANIFEST.in and `[tool.setuptools.package-data]` so the documentation files actually ship in built distributions:

- MANIFEST.in now includes README_PYPI.md, LICENSE, SECURITY.md, docs/formats.md, and every `*.md` under `fte/` (sdist side).
- `formats/regex/README.md` added to the `fte` package-data list (wheel side).

## Why

Two gaps, verified by building artifacts:

1. With MANIFEST.in trimmed to `include BUILDING.md`, setuptools 64-66 (versions the declared `>=64` floor in `pyproject.toml` allows) build an sdist that is missing README_PYPI.md, the file `pyproject.toml`'s `readme` field points at. An sdist without its declared readme fails to build metadata cleanly on those versions.
2. `fte/formats/regex/README.md` and `docs/formats.md` shipped in neither the wheel nor the sdist, even though the project documentation (README.md and the regex format README) points readers at them.

## Verification

Built both artifacts from this branch with `pyproject-build --no-isolation --outdir dist-check .` and listed their contents.

sdist (`tar tzf dist-check/fte-0.3.0.tar.gz`):

```
fte-0.3.0/BUILDING.md
fte-0.3.0/LICENSE
fte-0.3.0/README.md
fte-0.3.0/README_PYPI.md
fte-0.3.0/SECURITY.md
fte-0.3.0/docs/formats.md
fte-0.3.0/fte/formats/regex/README.md
```

wheel (`unzip -l dist-check/fte-0.3.0-py3-none-any.whl`):

```
     3118  08-30-2026 18:57   fte/formats/regex/README.md
```

Full test suite still passes: 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
