### PR TITLE
Standardize pattern/language/format/provider terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Format-Transforming Encryption (FTE) transforms ciphertext to match a target format: one given by a regular expression, or by any *ranked-format* provider you supply. Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify: hexadecimal strings, alphanumeric tokens, any pattern expressible as a regex, or a custom format such as decimal text or a domain-specific grammar.
+Format-Transforming Encryption (FTE) transforms ciphertext to match a target format: one given by a regular expression, or by any *ranked-format* provider you supply. Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify: hexadecimal strings, alphanumeric tokens, any language a regex can denote, or a custom format such as decimal text or a domain-specific grammar.
 
 This is useful for:
 - **Protocol obfuscation**: Make encrypted traffic look like benign data
@@ -19,7 +19,7 @@ Based on the paper [Protocol Misidentification Made Easy with Format-Transformin
 > **One engine.** libfte encrypts through a single path: `fte.FTE` over a
 > `RankedFormat` provider. Pass a `format` and a 32-byte `key`, then call
 > `encrypt` / `decrypt`. `fte.RegexFormat` is the built-in provider; supply your
-> own `RankedFormat` to target any other covertext format.
+> own `RankedFormat` to target any other covertext language.
 >
 > The wire format changed in 0.4.0 and is **not** compatible with libfte
 > 0.3.x and earlier.
@@ -168,9 +168,10 @@ messages may exceed the default, both endpoints should use the same value.
 
 ### `fte.RegexFormat`
 
-The built-in `RankedFormat`: a byte language compiled from a regular expression.
-Choose a fixed covertext length, or a `[min_length, max_length]` range for
-variable-length covertext (`min_length == max_length` is the fixed case).
+The built-in `RankedFormat`: a format over the byte language a regular
+expression denotes. Choose a fixed covertext length, or a
+`[min_length, max_length]` range for variable-length covertext
+(`min_length == max_length` is the fixed case).
 
 ```python
 fte.RegexFormat(pattern: str, *, length: int)                       # fixed
@@ -179,7 +180,7 @@ fte.RegexFormat(pattern: str, *, min_length: int, max_length: int)  # range
 
 | Member | Description |
 |--------|-------------|
-| `pattern` | The regular expression |
+| `pattern` | The regular expression denoting the covertext language |
 | `min_length`, `max_length` | Covertext length bounds (equal for a fixed length) |
 | `cardinality` | Number of matching words in the length range |
 | `rank(value: bytes) -> int` | Rank of a canonical covertext value |
@@ -212,13 +213,20 @@ performs capacity checks before encryption.
 
 The framing is variable-length. Anyone who can rank a covertext can infer its
 exact plaintext byte length, even without the key. FTE guarantees membership in
-the selected format, not a uniform distribution over every rank when the
-provider offers more capacity than the message needs.
+the format's language, not a uniform distribution over every rank when the
+format offers more capacity than the message needs.
 
-The capacity depends on your regex: more symbols means more bits per character:
+The vocabulary here is deliberate: a **pattern** (a regex) denotes a
+**language** (the set of matching words), a **format** ranks a finite slice of
+a language and is the wire contract endpoints must share, and a **provider**
+(such as `fte.formats.regex`, or your own `RankedFormat`) implements formats.
+See [Terminology](docs/formats.md#terminology) for the full glossary.
 
-| Format | Regex | Bits/char |
-|--------|-------|-----------|
+The capacity depends on the language: a larger alphabet means more bits per
+character:
+
+| Format | Pattern | Bits/char |
+|--------|---------|-----------|
 | Binary | `^[01]+$` | 1.0 |
 | Hex | `^[0-9a-f]+$` | 4.0 |
 | Alphanumeric | `^[A-Za-z0-9]+$` | 5.95 |

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -9,13 +9,13 @@
 
 ## What is FTE?
 
-Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify (via a regular expression, or any `RankedFormat` provider you supply), so it can look like hex strings, alphanumeric tokens, any regex-expressible pattern, or a custom format of your own.
+Unlike standard encryption that produces random-looking output, FTE produces ciphertext that looks like whatever format you specify (via a regular expression, or any `RankedFormat` provider you supply), so it can look like hex strings, alphanumeric tokens, any language a regex can denote, or a custom format of your own.
 
 > **One engine.** libfte encrypts through a single path: `fte.FTE` over a
 > `RankedFormat` provider. Pass a `format` and a 32-byte `key`, then call
 > `encrypt` / `decrypt`. `fte.RegexFormat` is the built-in provider; supply your
-> own `RankedFormat` for any other format. The wire format changed in 0.4.0
-> and is not compatible with libfte 0.3.x and earlier.
+> own `RankedFormat` for any other covertext language. The wire format changed
+> in 0.4.0 and is not compatible with libfte 0.3.x and earlier.
 
 ## Installation
 
@@ -82,8 +82,9 @@ assert cipher.decrypt(covertext) == b"secret"
 ```
 
 The key and exact ranked-format ordering must match at both endpoints. Generic
-FTE framing exposes plaintext length through the rank and guarantees format
-membership, not a uniform distribution over unused provider capacity.
+FTE framing exposes plaintext length through the rank and guarantees membership
+in the format's language, not a uniform distribution over unused format
+capacity.
 
 ## Use Cases
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -5,6 +5,22 @@ boundary: a non-negative integer rank. libfte owns encryption, authentication,
 versioned byte framing, and bytes-to-integer conversion. A format provider owns
 only the reversible mapping between ranks and canonical covertext values.
 
+## Terminology
+
+libfte's code and docs use four terms precisely:
+
+| Term | What it is | Example |
+|------|-----------|---------|
+| **pattern** (a regex) | Syntax: the string you write | `^[0-9a-f]+$` |
+| **language** | Semantics: the set of words a pattern denotes | all nonempty lowercase hex strings |
+| **format** | A finite slice of a language plus its canonical ordering (`rank`/`unrank`). The wire contract. | `RegexFormat(r'^[0-9a-f]+$', length=128)` |
+| **provider** | The mechanism that implements formats | `fte.formats.regex`, or your own `RankedFormat` class |
+
+In one line: a pattern denotes a language; a format ranks a finite slice of a
+language; a provider implements formats. Two different patterns can denote the
+same language, and one language yields many formats (different length bounds or
+orderings). Endpoints must agree on the format, not the pattern.
+
 ## Interface
 
 ```python
@@ -33,7 +49,7 @@ A provider must satisfy all of these rules:
 4. `unrank(rank(value)) == value` for every canonical covertext value.
 5. Both operations are deterministic and perform no randomness, encryption,
    key handling, network I/O, or text normalization.
-6. Values outside the canonical format and unsupported indexes are rejected.
+6. Values outside the format's language and unsupported indexes are rejected.
 7. The ordering is a wire-level compatibility contract. Both endpoints must
    use implementations with identical ranking behavior.
 
@@ -79,7 +95,7 @@ explicitly only to tighten that bound or to cap an unbounded provider.
 
 The version-one frame is variable length. Anyone who can rank a covertext can
 therefore infer its exact plaintext byte length without knowing the key. The
-mapping guarantees membership in the provider's language, but it is not uniform
+mapping guarantees membership in the format's language, but it is not uniform
 over unused rank capacity when a finite provider is much larger than the
 message requires. Applications needing length hiding or a target distribution
 must add an appropriate fixed-size record/padding layer before `FTE.encrypt`.
@@ -117,6 +133,11 @@ contain the complete encrypted message. Construction raises `ValueError` if the
 length arguments are missing, mixed, or not positive integers with
 `min_length <= max_length`; if `pattern` is not a valid regular expression; or if
 the language has no words in the requested length range.
+
+`regex2dfa` compiles the pattern to a minimized DFA, so two patterns that denote
+the same language produce byte-identical ranking: `^[ab]+$` and `^(a|b)+$`
+interoperate. The wire contract is the format (the language, the length bounds,
+and the ordering version), never the pattern's spelling.
 
 ## Provider checklist
 

--- a/examples/03_regex_formats.py
+++ b/examples/03_regex_formats.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Example: A gallery of regex covertext formats.
 
-The covertext language is entirely the regex you choose. The same engine and
+The pattern you choose denotes the covertext language. The same engine and
 key produce hex strings, alphanumeric tokens, or pronounceable words just by
 swapping the pattern.
 """
@@ -26,12 +26,12 @@ def main():
     key = os.urandom(32)  # 32-byte key, shared by both endpoints
     plaintext = b'Secret message'
 
-    for name, regex, length in FORMATS:
-        cipher = fte.FTE(format=fte.RegexFormat(regex, length=length), key=key)
+    for name, pattern, length in FORMATS:
+        cipher = fte.FTE(format=fte.RegexFormat(pattern, length=length), key=key)
         covertext = cipher.encrypt(plaintext)
 
         print(f"=== {name} ===")
-        print(f"  regex:     {regex}")
+        print(f"  pattern:   {pattern}")
         print(f"  covertext: {covertext.decode('latin-1')}")
         assert cipher.decrypt(covertext) == plaintext
         print()

--- a/examples/05_capacity_calculation.py
+++ b/examples/05_capacity_calculation.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Example: Understanding language capacity.
+"""Example: Understanding format capacity.
 
-This example explains how the capacity of a language affects
-how much data can be encrypted, and how to choose parameters.
+This example explains how the capacity of a format (a language sliced to a
+length range) determines how much data can be encrypted, and how to choose
+parameters.
 """
 
 import math
@@ -14,15 +15,15 @@ import fte
 KEY = bytes(range(32))  # capacity does not depend on the key value
 
 
-def analyze_language(name, regex, length):
-    """Analyze a language's capacity via its format cardinality."""
-    fmt = fte.RegexFormat(regex, length=length)
+def analyze_format(name, pattern, length):
+    """Analyze a format's capacity via its cardinality."""
+    fmt = fte.RegexFormat(pattern, length=length)
 
     # cardinality is the exact number of length-byte words in the language.
     capacity_bits = fmt.cardinality.bit_length() - 1  # floor(log2(cardinality))
 
     print(f"\n{name}:")
-    print(f"  Regex: {regex}")
+    print(f"  Pattern: {pattern}")
     print(f"  Output length: {length} bytes")
     print(f"  Capacity: {capacity_bits} bits")
 
@@ -39,12 +40,12 @@ def analyze_language(name, regex, length):
 
 
 def main():
-    print("=== Language Capacity Analysis ===")
+    print("=== Format Capacity Analysis ===")
     print("\nCapacity depends on alphabet size and output length.")
     print("More symbols = more bits per character.")
 
     # Compare different alphabets
-    languages = [
+    formats = [
         ("Binary (0-1)", "^[01]+$", 256),
         ("Hex (0-9a-f)", "^[0-9a-f]+$", 256),
         ("Lowercase (a-z)", "^[a-z]+$", 256),
@@ -53,8 +54,8 @@ def main():
     ]
 
     print("\n" + "="*60)
-    for name, regex, length in languages:
-        analyze_language(name, regex, length)
+    for name, pattern, length in formats:
+        analyze_format(name, pattern, length)
 
     print("\n" + "="*60)
     print("\nBits per character (theoretical):")
@@ -69,12 +70,12 @@ def main():
 
     test_data = b'A' * 100
 
-    for name, regex, length in [
+    for name, pattern, length in [
         ("Hex format", "^[0-9a-f]+$", 512),
         ("Alphanumeric", "^[A-Za-z0-9]+$", 256),
     ]:
         cipher = fte.FTE(
-            format=fte.RegexFormat(regex, length=length),
+            format=fte.RegexFormat(pattern, length=length),
             key=os.urandom(32),
         )
 

--- a/examples/06_error_handling.py
+++ b/examples/06_error_handling.py
@@ -46,7 +46,7 @@ def main():
     except fte.FormatCapacityError as e:
         print(f"   Caught FormatCapacityError: {e}")
 
-    # 5. Regex with no words of the requested length
+    # 5. Pattern with no words of the requested length
     print("\n5. Empty language for (pattern, length):")
     try:
         fte.RegexFormat('^(ab)+$', length=5)  # no words of odd length

--- a/examples/07_multiple_messages.py
+++ b/examples/07_multiple_messages.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 """Example: Encrypting multiple messages.
 
-Each covertext from a RegexFormat is exactly ``length`` bytes, so a stream of
-concatenated messages can be parsed back one fixed-size chunk at a time.
+Each covertext from a fixed-length RegexFormat is exactly ``length`` bytes, so
+a stream of concatenated messages can be parsed back one fixed-size chunk at a
+time.
 """
 
 import os

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ pip install fte
 | `02_custom_keys.py` | Using custom encryption keys |
 | `03_regex_formats.py` | A gallery of regex covertext formats |
 | `04_variable_length.py` | Variable-length covertext via `min_length`/`max_length` |
-| `05_capacity_calculation.py` | Understanding language capacity |
+| `05_capacity_calculation.py` | Understanding format capacity |
 | `06_error_handling.py` | Proper exception handling |
 | `07_multiple_messages.py` | Parsing a stream of fixed-length covertexts |
 | `08_custom_format.py` | Writing your own `RankedFormat` provider |
@@ -43,7 +43,7 @@ ciphertext = cipher.encrypt(b'secret message')
 plaintext = cipher.decrypt(ciphertext)
 ```
 
-To target a covertext language regex can't describe, supply your own
+To target a covertext language no regex denotes, supply your own
 `RankedFormat` (see `08_custom_format.py`).
 
 ## Choosing a Format
@@ -54,7 +54,7 @@ README for how alphabet size drives capacity.
 ## Tips
 
 1. **Larger `length`** = more capacity but longer covertext
-2. **More symbols in regex** = more bits per character
+2. **A larger alphabet in the pattern** = more bits per character
 3. **A fixed-`length` covertext is exactly `length` bytes**, so a stream of
    them slices into fixed-size chunks; a `min_length`/`max_length` covertext
    varies in length with the message (see `04_variable_length.py`)

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -17,7 +17,7 @@ Example usage:
     >>> assert cipher.decrypt(covertext) == b'secret message'
 
 ``fte.RegexFormat`` is the built-in regex provider; supply your own
-:class:`fte.RankedFormat` to target any other covertext format. See
+:class:`fte.RankedFormat` to target any other covertext language. See
 :mod:`fte.formats` for the provider contract and the reference implementation.
 
 See the paper "Protocol Misidentification Made Easy with Format-Transforming

--- a/fte/formats/__init__.py
+++ b/fte/formats/__init__.py
@@ -2,9 +2,9 @@
 
 A provider is the one thing you supply to the engine to choose what covertext
 looks like. :mod:`~fte.formats.base` defines the contract every provider
-implements. Each concrete format lives in its own subpackage;
+implements. Each provider lives in its own subpackage;
 :mod:`~fte.formats.regex` is the built-in reference implementation and the
-subpackage to copy for a new format.
+subpackage to copy for a new provider.
 
     >>> import fte
     >>> from fte.formats import RegexFormat

--- a/fte/formats/base.py
+++ b/fte/formats/base.py
@@ -31,7 +31,7 @@ class RankedFormat(Protocol[Covertext]):
 
     The ordering is part of the wire format. Sender and receiver must therefore
     use compatible implementations and versions. Implementations should reject
-    values outside their canonical format and indexes outside their capacity.
+    values outside the format's language and indexes outside their capacity.
 
     The protocol is structural: any object with callable ``rank`` and ``unrank``
     methods conforms, with no need to subclass or import this module at runtime.

--- a/fte/formats/regex/README.md
+++ b/fte/formats/regex/README.md
@@ -1,9 +1,10 @@
 # `fte.formats.regex`
 
 The built-in ranked-format provider, and the reference implementation to copy
-when you write your own. `RegexFormat` compiles a regular expression into a
-ranked byte language, so `fte.FTE` ciphertext comes out looking like the pattern
-you chose: hex, alphanumeric tokens, URL paths, lowercase words, and so on.
+when you write your own. `RegexFormat` compiles a pattern into a format, a
+ranked slice of the byte language the pattern denotes, so `fte.FTE` ciphertext
+comes out looking like the pattern you chose: hex, alphanumeric tokens, URL
+paths, lowercase words, and so on.
 
 ## Example
 
@@ -22,8 +23,8 @@ assert cipher.decrypt(covertext) == b'secret'
 
 ## Fixed vs variable length
 
-A regular expression like `^[0-9a-f]+$` describes an infinite language, so you
-bound it to make it rankable. There are two ways:
+A pattern like `^[0-9a-f]+$` denotes an infinite language, so you bound it to
+make it rankable. There are two ways:
 
 - **Fixed length.** `RegexFormat(pattern, length=N)` ranks the words of exactly
   `N` bytes, so every covertext is `N` bytes. This is the classic fixed-slice
@@ -43,7 +44,7 @@ Pass either `length`, or the `min_length`/`max_length` pair, not both.
 ## Choosing a length
 
 The covertext has to be big enough to hold FTE's authenticated frame (a fixed
-33-byte overhead plus the message). If the language is too small for even an
+33-byte overhead plus the message). If the format is too small for even an
 empty message, `fte.FTE(...)` raises `FormatCapacityError` at construction. As a
 rule of thumb, capacity grows with the alphabet size and the length: for the hex
 format above, `length=128` holds up to 31 plaintext bytes
@@ -59,14 +60,18 @@ language has no words in the requested length range.
   on. It counts and ranks the words of the language by length.
 
 The engine (`fte.FTE`) owns encryption, authentication, and framing; this
-subpackage owns only the covertext language. That separation is exactly what
-makes a new format easy to add.
+subpackage owns only the ranking of the covertext language. That separation is
+exactly what makes a new provider easy to add.
 
-## Writing your own format
+Because `regex2dfa` produces a minimized DFA, two patterns denoting the same
+language rank identically: the format depends on the language and length
+bounds, not on the pattern's spelling.
+
+## Writing your own provider
 
 `RegexFormat` is just one implementation of the structural `RankedFormat`
 contract (any object with reversible `rank`/`unrank`). To target a covertext
-language a regex cannot describe, write your own provider. See the
+language no regex denotes, write your own provider. See the
 [ranked-format provider guide](../../../docs/formats.md) for the contract and a
 conformance checklist, and `examples/08_custom_format.py` for a small worked
 provider.

--- a/fte/formats/regex/__init__.py
+++ b/fte/formats/regex/__init__.py
@@ -1,8 +1,9 @@
-"""The built-in regular-expression ranked format.
+"""The built-in regular-expression ranked-format provider.
 
-This subpackage holds everything regex-specific: :class:`RegexFormat`, the
-provider you hand to :class:`fte.FTE`, and the DFA ranker it is built on. Every
-other format lives in its own sibling subpackage under :mod:`fte.formats`.
+This subpackage holds everything regex-specific: :class:`RegexFormat`, whose
+instances are the formats you hand to :class:`fte.FTE`, and the DFA ranker it
+is built on. Every other provider lives in its own sibling subpackage under
+:mod:`fte.formats`.
 """
 
 from fte.formats.regex.format import RegexFormat

--- a/fte/formats/regex/format.py
+++ b/fte/formats/regex/format.py
@@ -1,9 +1,9 @@
 """``RegexFormat``: the reference :class:`~fte.formats.base.RankedFormat`.
 
-This is the format libfte ships with, and the worked example to copy when you
-write your own provider. It turns a regular expression into a ranked byte
-language, so ciphertext comes out looking like the pattern you chose: hex,
-alphanumeric tokens, URL paths, and so on.
+This is the provider libfte ships with, and the worked example to copy when you
+write your own. Each instance is a format: a ranked, finite slice of the byte
+language a pattern denotes, so ciphertext comes out looking like the pattern
+you chose: hex, alphanumeric tokens, URL paths, and so on.
 
 Covertext length is the format's choice, not the engine's. ``RegexFormat`` lets
 you pin it or leave it to vary:
@@ -19,7 +19,7 @@ you pin it or leave it to vary:
 There is deliberately no cryptography here. Compiling and ranking the DFA (in
 the sibling :mod:`~fte.formats.regex.dfa` module) is the provider's only job;
 :class:`fte.FTE` owns encryption, authentication, and framing. That separation
-is exactly what makes a new format easy to add.
+is exactly what makes a new provider easy to add.
 """
 
 from __future__ import annotations
@@ -48,7 +48,7 @@ class RegexFormat:
     encrypting it.
 
     Args:
-        pattern: A regular expression describing the covertext language.
+        pattern: A regular expression denoting the covertext language.
         length: A single fixed covertext length. Shorthand for
             ``min_length == max_length == length``. Mutually exclusive with
             ``min_length`` / ``max_length``.
@@ -127,8 +127,9 @@ class RegexFormat:
             ) from exc
         dfa = DFA(dfa_str, hi)
 
-        # Order the language by length first, then lexicographically within a
-        # length. Record where each length starts in the combined rank space.
+        # Order the language's slice by length first, then lexicographically
+        # within a length. Record where each length starts in the combined rank
+        # space.
         offsets = {}
         counts = {}
         cumulative = 0


### PR DESCRIPTION
## What

Re-lands #67, which was merged into `encrypt-decrypt-api` about an hour after #61 had already merged that branch, so its content never reached master. This is the last unmerged content on that branch; once this lands, `encrypt-decrypt-api` can be deleted.

The vocabulary (from the glossary this adds to `docs/formats.md` and the README): a **pattern** (a regex) denotes a **language**; a **format** ranks a finite slice of a language and is the wire contract endpoints must share; a **provider** implements formats. It also documents that `regex2dfa`'s minimized DFAs make two patterns denoting the same language rank identically, so the wire contract is the format, never the pattern's spelling.

## Conflict resolutions

Three files conflicted with master's post-#61 work; all resolved in favor of master's newer structure with the terminology applied on top:

- `README_PYPI.md`: kept master's "changed in 0.4.0" wording, applied "any other covertext language"
- `examples/README.md`: kept master's renumbered 01-08 example table and slimmed format-choosing section
- `fte/core.py`: kept master's docstring wholesale, since the #77 frame split already rewrote it with the right terminology

## New drift fixed

Files added to master after the branch point, which #67 never saw:

- `examples/03_regex_formats.py`: "The covertext language is entirely the regex you choose" conflated pattern and language; also renamed the `regex` loop variable and print label to `pattern`, matching #67's identical rename in the capacity example
- `examples/README.md`: the table described `05_capacity_calculation.py` as "language capacity" while the example's own docstring (per #67) says "format capacity"; capacity belongs to the finite slice, not the infinite language

## Verification

Full suite with the repo venv: 1133 passed, 145 skipped. Examples 03, 05, 06, and 07 (the touched ones) all run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)