### PR TITLE
Cite the libFTE USENIX Security 2014 toolkit paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is useful for:
 - **Bypassing filters**: Evade systems that block encrypted-looking content
 - **Constrained fields**: Confine ciphertext to a required character set or field shape, such as an alphanumeric account token or a fixed-width record field
 
-Based on the paper [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf) (CCS 2013).
+Based on the papers [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf) (CCS 2013), which introduced the FTE scheme, and [LibFTE: A Toolkit for Constructing Practical, Format-Abiding Encryption Schemes](https://kpdyer.com/publications/usenix2014-fte.pdf) (USENIX Security 2014), which described the FPE/FTE toolkit this library is named for. See [References](#references).
 
 ### One engine, two axes
 
@@ -331,6 +331,10 @@ mean larger integers in the rank/unrank arithmetic. Use
 [1] [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf)
     Kevin P. Dyer, Scott E. Coull, Thomas Ristenpart and Thomas Shrimpton
     ACM CCS 2013
+
+[2] [LibFTE: A Toolkit for Constructing Practical, Format-Abiding Encryption Schemes](https://kpdyer.com/publications/usenix2014-fte.pdf)
+    Daniel Luchaup, Kevin P. Dyer, Somesh Jha, Thomas Ristenpart and Thomas Shrimpton
+    USENIX Security 2014
 
 ## License
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -100,7 +100,7 @@ Full docs and examples: [github.com/kpdyer/libfte](https://github.com/kpdyer/lib
 
 ## Reference
 
-Based on [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf) (ACM CCS 2013).
+Based on [Protocol Misidentification Made Easy with Format-Transforming Encryption](https://kpdyer.com/publications/ccs2013-fte.pdf) (ACM CCS 2013) and [LibFTE: A Toolkit for Constructing Practical, Format-Abiding Encryption Schemes](https://kpdyer.com/publications/usenix2014-fte.pdf) (USENIX Security 2014).
 
 ## License
 

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -36,7 +36,10 @@ the raw-bytes identity format (the default input). Supply your own
 for the provider contract and the reference implementation.
 
 See the paper "Protocol Misidentification Made Easy with Format-Transforming
-Encryption" for details: https://kpdyer.com/publications/ccs2013-fte.pdf
+Encryption" for scheme details (https://kpdyer.com/publications/ccs2013-fte.pdf)
+and "LibFTE: A Toolkit for Constructing Practical, Format-Abiding Encryption
+Schemes" for the FPE/FTE toolkit this library is named for
+(https://kpdyer.com/publications/usenix2014-fte.pdf).
 """
 
 from pathlib import Path

--- a/fte/_encrypter.py
+++ b/fte/_encrypter.py
@@ -5,7 +5,8 @@
 This module provides authenticated encryption using AES-CTR mode
 with HMAC-SHA512 for message authentication.
 
-See https://kpdyer.com/publications/ccs2013-fte.pdf for scheme details.
+See https://kpdyer.com/publications/ccs2013-fte.pdf for scheme details, and
+https://kpdyer.com/publications/usenix2014-fte.pdf for the libFTE toolkit.
 """
 
 from Crypto.Cipher import AES


### PR DESCRIPTION
Adds a citation to the USENIX Security 2014 paper *LibFTE: A Toolkit for Constructing Practical, Format-Abiding Encryption Schemes* (Luchaup, Dyer, Jha, Ristenpart, Shrimpton), the FPE/FTE toolkit this library is named for, alongside the already-cited CCS 2013 scheme paper.

Reference added in four places:
- `README.md` intro and References section (entry `[2]`)
- `README_PYPI.md` Reference section
- `fte/__init__.py` module docstring
- `fte/_encrypter.py` module docstring

Docs and docstrings only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)