### PR TITLE
perf(frame): compute rank_offset in O(n) instead of 256**length

### DIFF
--- a/fte/frame.py
+++ b/fte/frame.py
@@ -8,6 +8,8 @@ both endpoints, so any change breaks compatibility with existing peers.
 
 from __future__ import annotations
 
+import functools
+
 
 __all__ = [
     "FRAME_VERSION",
@@ -25,10 +27,19 @@ __all__ = [
 FRAME_VERSION = b"\x01"
 
 
+@functools.lru_cache(maxsize=16)
 def rank_offset(length: int) -> int:
-    """Return the first rank assigned to byte strings of ``length``."""
+    """Return the first rank assigned to byte strings of ``length``.
 
-    return (256 ** length - 1) // 255
+    ``(256 ** length - 1) // 255`` equals ``0x0101...01`` (``length`` bytes of
+    ``0x01``): the sum of ``256**i`` for ``i`` in ``range(length)``. Building it
+    with ``int.from_bytes`` is O(length); the old ``256 ** length`` raised 256 to
+    the frame's byte length on every call, which dominated encrypt/decrypt for
+    large frames. The cache is keyed on ``length`` (a handful of frame sizes are
+    in flight at once), so repeated same-size records skip the rebuild entirely.
+    """
+
+    return int.from_bytes(b"\x01" * length, "big")
 
 
 def bytes_to_rank(value: bytes) -> int:
@@ -55,7 +66,10 @@ def rank_byte_length(index: int) -> int:
 def frame_rank_limit(frame_length: int) -> int:
     """Return the exclusive upper rank bound for version-one frames."""
 
-    return rank_offset(frame_length) + 2 * 256 ** (frame_length - 1)
+    # 2 * 256 ** (frame_length - 1) == 0x02 followed by frame_length-1 zero
+    # bytes; build it in O(frame_length) rather than exponentiating 256.
+    high = int.from_bytes(b"\x02" + b"\x00" * (frame_length - 1), "big")
+    return rank_offset(frame_length) + high
 
 
 def capacity_plaintext_limit(cardinality: int, expansion: int) -> int:

--- a/tests/test_bytes_format.py
+++ b/tests/test_bytes_format.py
@@ -50,6 +50,25 @@ class Tests(unittest.TestCase):
         one_byte = sorted(bytes_to_rank(bytes([b])) for b in range(256))
         self.assertEqual(one_byte, list(range(rank_offset(1), rank_offset(2))))
 
+    def test_rank_offset_matches_closed_form(self):
+        # rank_offset(n) is 0x0101..01 (n bytes of 0x01): the sum of 256**i for
+        # i in range(n), i.e. (256**n - 1) // 255. Guards the O(n) rewrite
+        # against regressing to (or diverging from) the closed form.
+        for length in (0, 1, 2, 5, 17, 64, 255, 256, 1000):
+            self.assertEqual(rank_offset(length), (256 ** length - 1) // 255)
+            self.assertEqual(
+                rank_offset(length), int.from_bytes(b"\x01" * length, "big")
+            )
+
+    def test_frame_rank_limit_matches_closed_form(self):
+        from fte.frame import frame_rank_limit
+
+        for frame_length in (1, 2, 5, 33, 128, 300):
+            self.assertEqual(
+                frame_rank_limit(frame_length),
+                rank_offset(frame_length) + 2 * 256 ** (frame_length - 1),
+            )
+
     def test_rank_rejects_non_bytes(self):
         with self.assertRaises(TypeError):
             self.fmt.rank("not bytes")


### PR DESCRIPTION
## Summary

`frame.rank_offset()` computed `(256 ** length - 1) // 255` — raising 256 to the frame's **byte length** — on every call, and it is called ~2x per `encrypt` and ~2x per `decrypt` (via `bytes_to_rank` / `rank_to_bytes`). For large frames that exponentiation dominates the whole operation. This replaces it with the mathematically identical O(length) closed form.

`(256 ** length - 1) // 255` is exactly `0x0101…01` (`length` bytes of `0x01`) — the sum of `256**i` for `i in range(length)` — so it is `int.from_bytes(b"\x01" * length, "big")`. The same pattern in `frame_rank_limit` (`2 * 256 ** (frame_length - 1)`) is rewritten the same way.

No wire-format or value change: every rank is byte-identical to before. This is purely a speed fix.

## Impact

Profiling `BytesFormat` encrypt+decrypt (64 KiB payload, 50 iters) put **84% of total time inside `rank_offset`**. After the fix, throughput for a raw-bytes body reaches parity with the pre-0.4 code path:

| payload | `BytesFormat` before | after |
|---:|---:|---:|
| 16 KiB | 8.9 MB/s | 50 MB/s |
| 256 KiB | 8.4 MB/s | 64 MB/s |
| 1 MiB | 8.5 MB/s | 65 MB/s |

The win scales with frame size, so it is largest for `BytesFormat` and other high-capacity formats carrying bulk data; small formatted covertexts (a few hundred bytes) improve modestly. `frame_rank_limit` runs at construction time, so its rewrite trims cipher-build cost for large-frame formats rather than the hot path.

## Notes

- `rank_offset` is memoized with `functools.lru_cache(maxsize=16)`: a handful of frame sizes are usually in flight, so repeated same-size records skip the rebuild entirely (this is the difference between ~50 and ~65 MB/s at 256 KiB). `maxsize` is bounded so the cached big integers cannot accumulate without limit.
- Added closed-form correctness tests for both `rank_offset` and `frame_rank_limit`. Full suite: `1179 passed, 146 skipped` (the skips are the FPE tests, which need an unreleased `libffx>=2.0.0`; unrelated to this change).

## Why it matters

This unblocks a fast path for downstream framing layers (e.g. fteproxy): a short FTE-formatted header plus a `BytesFormat` body now runs at raw-AEAD speed while staying entirely inside libfte's audited cipher, with no per-byte DFA cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
