### PR TITLE
docs: bring README, guides, examples, and benchmark in line with the 0.4.0 code

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,11 +1,17 @@
 # libfte Build Instructions
 
-libfte is a pure Python package. There is nothing to compile and no system
-libraries are required.
+libfte itself is pure Python; there is nothing in this repository to compile.
+It depends on two packages:
+
+- `cryptography` (AES-CTR): a compiled extension that bundles OpenSSL. PyPI
+  ships prebuilt wheels for supported platforms, so no compiler is normally
+  needed.
+- `regex2dfa` (pattern compilation): pure Python.
 
 ## Requirements
 
 - Python 3.10 or later
+- Network access to PyPI (or a mirror) for the dependencies above
 
 ## Install
 
@@ -20,6 +26,14 @@ For development (tests and coverage):
 ```bash
 pip install -e ".[dev]"
 ```
+
+The optional `fpe` extra adds `libffx>=2.0.0`, which provides `cipher="ff1"`:
+
+```bash
+pip install -e ".[dev,fpe]"
+```
+
+Without it, `tests/test_ff1_integration.py` and examples 10 and 11 skip.
 
 ## Verification
 
@@ -49,4 +63,8 @@ pip install build
 python -m build
 ```
 
-This produces a source distribution and a pure Python wheel in `dist/`.
+This produces a source distribution and a `py3-none-any` wheel in `dist/`.
+`python -m build` creates an isolated build environment and installs
+`setuptools>=77` (the floor declared in `pyproject.toml`) into it, so it needs
+network access; with `setuptools>=77` already installed,
+`python -m build --no-isolation` builds offline.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013-2025 Kevin P. Dyer
+Copyright (c) 2013-2026 Kevin P. Dyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ That gives a 2x2 of behaviors:
 
 `cipher="ff1"` is the built-in format-preserving cipher (NIST SP 800-38G FF1,
 via the optional [libffx](https://github.com/kpdyer/libffx) extra:
-`pip install fte[fpe]`). The deterministic column also takes any object with
+`pip install 'fte[fpe]'`). The deterministic column also takes any object with
 `encrypt_int(x, *, domain, tweak)` / `decrypt_int(y, *, domain, tweak)` forming
 a permutation of `range(domain)`, so you can supply your own cipher.
 
@@ -67,22 +67,28 @@ import fte
 key = os.urandom(32)  # 32 bytes, shared by both endpoints
 
 # Pick a covertext format, then build a cipher over it and the key.
-word_format = fte.RegexFormat(r'^([a-z]+ )+[a-z]+$', length=80)
+# 73 characters of words hold up to 15 plaintext bytes (cipher.max_plaintext_bytes).
+word_format = fte.RegexFormat(r'^([a-z]+ )+[a-z]+$', length=73)
 cipher = fte.FTE(output_format=word_format, key=key)
 
 ciphertext = cipher.encrypt(b'Attack at dawn')
 print(ciphertext.decode())
-# → "a kgxbpxy vpgdigzczzkwlgmapocgjzspnqzilpyhezdbtxalonocvhlpc bbtflzgxhjjjpvmmnvvu"
+# One real run; the exact text varies per call, because the cipher is randomized:
+# aa migbcjfbkvhczkjjwogvkpr m hnczwlthnujcutvnxqtrfhfnvnjhowaax mg nazfkrf
 
 plaintext = cipher.decrypt(ciphertext)
 # → b'Attack at dawn'
 ```
 
-The ciphertext looks like random text but contains your encrypted message.
+The covertext is a string of the chosen format that carries your encrypted
+message. Because the format holds one byte more than the message needs, the
+covertext can begin with a short run of the format's lowest-ranked symbols
+(`a` and space); a much larger `length` would make that run long (see
+[How It Works](#how-it-works)).
 
 For **format-preserving encryption**, use the same format on both sides. Equal
 formats infer the deterministic `ff1` cipher, and length is preserved
-automatically (needs `pip install fte[fpe]`):
+automatically (needs `pip install 'fte[fpe]'`):
 
 ```python
 digits = fte.RegexFormat(r'^[0-9]+$', length=9)   # a 9-digit language
@@ -94,27 +100,30 @@ assert fpe.decrypt(token, tweak=b'accounts') == b'100000042'
 
 ## More Examples
 
-The snippets below reuse a shared 32-byte `key = os.urandom(32)`.
+The snippets below reuse a shared 32-byte `key = os.urandom(32)`. Each
+`length` is the smallest that holds one byte more than the 6-byte message; the
+outputs shown are from one real run, and yours will differ (the cipher is
+randomized).
 
 ### URL paths
 ```python
-cipher = fte.FTE(output_format=fte.RegexFormat(r'^/[a-z]+/[a-z]+\.html$', length=96), key=key)
+cipher = fte.FTE(output_format=fte.RegexFormat(r'^/[a-z]+/[a-z]+\.html$', length=66), key=key)
 cipher.encrypt(b'secret')
-# → "/hsdxanghqvdhb/pvzvdsrpnjktdhnewdfhehaftajibecrluewdyrbe...html"
+# → b'/aagkbylrumwypuvsxjwymsedkpqvcfnspezlgoivwgjjzruert/vtgmhuzfl.html'
 ```
 
 ### URL slugs
 ```python
-cipher = fte.FTE(output_format=fte.RegexFormat(r'^[a-z]+-[a-z]+-[a-z]+$', length=80), key=key)
+cipher = fte.FTE(output_format=fte.RegexFormat(r'^[a-z]+-[a-z]+-[a-z]+$', length=60), key=key)
 cipher.encrypt(b'secret')
-# → "dxosmywnpyjuarsfvcado-osmdsyvovfnnsgzhzelpujnya-qfwbekwh..."
+# → b'a-qogwiyjqkhmakfxo-jhszhdlrpqeskjmolsfnmnskmzsixfjiilmimwkhb'
 ```
 
 ### Alphanumeric tokens
 ```python
-cipher = fte.FTE(output_format=fte.RegexFormat('^[A-Za-z0-9]+$', length=64), key=key)
+cipher = fte.FTE(output_format=fte.RegexFormat('^[A-Za-z0-9]+$', length=48), key=key)
 cipher.encrypt(b'secret')
-# → "Kj8mNp2xQw4yLr9vBn3cHt6sFg0dAe5iUo7lMz1bXk..."
+# → b'00ZO60lS5n5KAI37NT9baatQ2mSvF3zKOZaDOGwzYHuTz1yF'
 ```
 
 ### Variable-length covertext
@@ -124,12 +133,12 @@ fixed case):
 ```python
 lowercase = fte.RegexFormat('^[a-z]+$', min_length=40, max_length=400)
 cipher = fte.FTE(output_format=lowercase, key=key)
-cipher.encrypt(b'secret')       # a lowercase string somewhere in 40..400 bytes
+cipher.encrypt(b'secret')       # a lowercase string in 40..400 bytes (59 for this message)
 ```
 
 ### Custom ranked-format providers
 
-The `format` can be any structural `RankedFormat`: an object with reversible
+The `output_format` can be any structural `RankedFormat`: an object with reversible
 `rank()` and `unrank()` methods. No inheritance, registration, or dependency
 between libfte and the provider is required. `fte.RegexFormat` is just the
 built-in one (see [`fte/formats/`](fte/formats/)):
@@ -193,7 +202,7 @@ fte.FTE(
 
 | Member | Description |
 |--------|-------------|
-| `encrypt(plaintext, *, tweak=b"") -> T` | Rank the input, transform, unrank into a covertext (tweak: deterministic cipher only) |
+| `encrypt(plaintext, *, tweak=b"") -> T` | Rank the input, transform, unrank into a covertext (tweak: deterministic cipher only; a non-empty tweak with `aes-ctr-hmac` raises `ValueError`) |
 | `decrypt(covertext, *, tweak=b"") -> P` | Rank the covertext, invert the transform, unrank the plaintext |
 | `input_format` / `output_format` | The two formats |
 | `cipher` | Resolved mode: `"aes-ctr-hmac"` or `"deterministic"` |
@@ -205,7 +214,7 @@ The `cipher` is `"aes-ctr-hmac"`, `"ff1"`, a deterministic cipher **object**
 input picks `"aes-ctr-hmac"`; two formats with equal fingerprints pick `"ff1"`;
 any other pair must name the cipher. `"aes-ctr-hmac"` needs a 32-byte key (16
 encryption + 16 MAC); `"ff1"` needs 16/24/32 and requires the extra
-(`pip install fte[fpe]`); a cipher object carries its own key.
+(`pip install 'fte[fpe]'`); a cipher object carries its own key.
 
 A deterministic cipher infers **length preservation** from the formats: when
 input and output are the same format and it can name its per-length slices, a
@@ -238,10 +247,30 @@ fte.RegexFormat(pattern: str, *, min_length: int, max_length: int)  # range
 | `cardinality` | Number of matching words in the length range |
 | `rank(value: bytes) -> int` | Rank of a canonical covertext value |
 | `unrank(index: int) -> bytes` | The covertext value at `index` |
+| `fingerprint` | `bytes`: SHA-256 over the pattern text and length bounds. Equal fingerprints guarantee identical ranking and infer the `ff1` cipher; two spellings of one language (`^[ab]+$` and an equivalent pattern written differently) rank identically but get different fingerprints, so use the same pattern string at both endpoints of a deterministic cipher |
+| `slice_bounds(length: int, /) -> tuple[int, int]` | `(offset, count)` of the words of exactly `length` bytes within the rank space (`ValueError` outside `[min_length, max_length]`); what lets FPE preserve length |
 
 `length=N` is shorthand for `min_length=max_length=N`; pass either `length` or
 the `min_length`/`max_length` pair, not both. Construction raises `ValueError`
 if the language has no words in the requested length range.
+
+### `fte.BytesFormat`
+
+The default `input_format`: the shortlex ranked format over every finite byte
+string, ordered by length and then numerically (`b''` ranks 0, the 256
+single bytes rank 1..256, two-byte strings follow, and so on), so length and
+leading zero bytes survive `rank`/`unrank`. The language is unbounded, so it
+exposes no `cardinality`; it is the same ordering the wire frame uses.
+
+```python
+fte.BytesFormat()
+```
+
+| Member | Description |
+|--------|-------------|
+| `rank(value: bytes) -> int` | Shortlex rank of `value` |
+| `unrank(index: int) -> bytes` | The byte string at `index`, for any `index >= 0` |
+| `fingerprint` | `b"fte:bytes:shortlex:1"`: names the ordering as part of the wire contract |
 
 ### `fte.RankedFormat`
 
@@ -258,16 +287,47 @@ Formats must use contiguous non-negative ranks and satisfy
 additionally expose an exact positive `cardinality` attribute; libfte then
 performs capacity checks before encryption.
 
+### Exceptions
+
+Every engine error derives from `fte.FTEError`; bad arguments (a wrong key
+size, an unknown `cipher`, an invalid pattern) raise `TypeError` or
+`ValueError` instead.
+
+| Exception | Raised when |
+|-----------|-------------|
+| `FTEError` | Base class of the errors below |
+| `FormatCapacityError` | A format cannot hold an encrypted frame: at construction when the output format is too small for even an empty message (or, with a non-bytes input, for every input rank), or when a deterministic cipher's input cardinality exceeds its output's (or either format is unbounded); at `encrypt` when a plaintext exceeds a finite output's capacity |
+| `FormatContractError` | A format breaks the `RankedFormat` contract: a `cardinality` that is not a positive integer, or a covertext `rank()` that returns something other than a non-negative integer |
+| `InvalidCovertextError` | `decrypt` cannot recover a plaintext: the covertext is not in the output language, is oversized, has the wrong frame version, fails authentication, or (deterministic cipher) deciphers outside the input format's rank space |
+| `InvalidPlaintextError` | `encrypt` is given a value that is not a member of a non-bytes `input_format` (its `rank()` fails or falls outside the rank space); a non-bytes plaintext for the bytes input is a `TypeError` |
+| `MessageTooLargeError` | A bytes plaintext exceeds the configured ceiling (the `max_plaintext_bytes` argument, or the 1 MiB default); exceeding a finite format's capacity is `FormatCapacityError` instead |
+| `SmallDomainError` | A deterministic cipher's domain is below the one-million floor: a non-empty length slice with fewer than a million words when length is preserved, or an output domain with fewer than a million values for a cross-format map |
+
 ## How It Works
 
-1. **Encryption**: Your plaintext is encrypted with AES-CTR and authenticated with HMAC-SHA512
-2. **Framing**: The ciphertext is mapped reversibly to a non-negative integer
-3. **Formatting**: A built-in or custom ranked format maps that integer to covertext
+1. **Encryption**: Your plaintext is encrypted with AES-128-CTR under a fresh
+   12-byte random nonce, then authenticated with HMAC-SHA256 over the nonce
+   and ciphertext (Encrypt-then-MAC; the tag is truncated to 16 bytes). The
+   32-byte key is split into a 16-byte AES key and a 16-byte MAC key. Both
+   primitives run on OpenSSL: AES-CTR through the `cryptography` package, HMAC
+   through the standard library's `hmac`/`hashlib`.
+2. **Framing**: A one-byte wire-format version is prepended, so an `n`-byte
+   plaintext becomes an `n + 29`-byte frame (`1 + 12 + n + 16`), and the frame
+   is mapped reversibly to a non-negative integer: its shortlex rank (length
+   first, then value; the `BytesFormat` ordering).
+3. **Formatting**: A built-in or custom ranked format maps that integer to a
+   covertext with `unrank()`; `decrypt()` runs the steps in reverse and
+   rejects a covertext whose tag does not verify with `InvalidCovertextError`.
 
 The framing is variable-length. Anyone who can rank a covertext can infer its
 exact plaintext byte length, even without the key. FTE guarantees membership in
 the format's language, not a uniform distribution over every rank when the
-format offers more capacity than the message needs.
+format offers more capacity than the message needs. Concretely, the frame's
+rank is only about `8 * (n + 29)` bits long, so when the format's cardinality
+is much larger a fixed-length covertext begins with a run of the format's
+lowest-ranked symbols (leading `0`s for hex, `a a a` for the word format) that
+grows with the unused capacity. Keep `length` close to what the message needs
+(`cipher.max_plaintext_bytes` reports the fit) to keep that run short.
 
 The vocabulary here is deliberate: a **pattern** (a regex) denotes a
 **language** (the set of matching words), a **format** ranks a finite slice of
@@ -292,39 +352,49 @@ script that measures the two costs that matter in practice:
 - **Cipher construction**: the one-time cost of compiling a regex into a DFA
   and pre-computing the ranking tables.
 - **`encrypt()` / `decrypt()`**: the per-message cost, dominated by the DFA
-  rank/unrank over large integers. This scales with the covertext `length`,
-  *not* with the plaintext size.
+  rank/unrank over large integers. It grows with the covertext `length` (the
+  DFA walk) and with the plaintext size (the magnitude of the integer being
+  ranked), so every format is timed twice: with a short 18-byte payload and
+  with a payload that fills the format's capacity (`max_plaintext_bytes`).
 
-It runs across the built-in formats (binary, hex, alphanumeric, words, URLs),
-sweeps `length` to show how per-message cost scales, and records the CPU /
-OS / Python it ran on. Every timed round-trip is verified, so a clean run also
-serves as a correctness check.
+It runs across six formats (binary, hex, lowercase, alphanumeric, URL paths,
+words), sweeps `length` for `^[a-z]+$` to show how per-message cost scales,
+and records the CPU / OS / Python it ran on. Every timed round-trip is
+verified, so a clean run also serves as a correctness check.
 
 ```bash
-python benchmark.py            # full run
-python benchmark.py --quick    # fewer iterations, skip the length sweep
+python benchmark.py            # full run: 100 iterations, with the length sweep
+python benchmark.py --quick    # 20 iterations, skip the length sweep
 ```
 
-Example output (Apple M3 Pro):
+Numbers are machine-dependent. One full run on an Apple M3 Pro (Python 3.14;
+times in ms, median of 100 iterations):
 
 ```
-Per-format performance
-Format          length  cap(bits)  bits/char   build(ms)  encrypt(ms)  decrypt(ms)
-----------------------------------------------------------------------------------
-Binary             512        512       1.00       0.24         0.098        0.087
-Hex                256       1024       4.00       0.68         0.087        0.061
-Alphanumeric       192       1143       5.95       1.79         0.076        0.053
+Per-format performance (per-message times in ms)
+Format          length  cap(bits)  bits/char   build(ms)  enc/small  dec/small  max(B)   enc/max   dec/max
+----------------------------------------------------------------------------------------------------------
+Binary             512        512       1.00       0.110      0.051      0.043      35     0.060     0.050
+Hex                256       1024       4.00       0.076      0.026      0.020      99     0.046     0.037
+Lowercase          256       1203       4.70       0.082      0.026      0.021     122     0.047     0.040
+Alphanumeric       192       1143       5.95       0.097      0.021      0.017     114     0.039     0.031
+URL path           128        575       4.49       0.186      0.031      0.030      43     0.038     0.037
+Words              120        570       4.75       0.120      0.031      0.028      43     0.037     0.035
 
 Per-message scaling vs. length (regex ^[a-z]+$)
-length   cap(bits)  encrypt(ms)  decrypt(ms)
---------------------------------------------
-256           1203        0.095        0.059
-2048          9626        3.076        1.198
+length    cap(bits)  enc/small  dec/small  max(B)   enc/max   dec/max
+---------------------------------------------------------------------
+128             601      0.019      0.016      47     0.023     0.020
+256            1203      0.028      0.021     122     0.047     0.039
+512            2406      0.046      0.034     272     0.132     0.098
+1024           4813      0.082      0.059     573     0.436     0.293
+2048           9626      0.152      0.111    1175     1.612     0.943
 ```
 
-Per-message cost grows super-linearly with `length`, since larger outputs
-mean larger integers in the rank/unrank arithmetic. Use
-`python benchmark.py --help` for all options.
+For a short payload the per-message cost grows more slowly than `length` does
+(about 8x from 128 to 2048); a payload that fills the capacity grows
+super-linearly (about 70x over the same range), since the integer being ranked
+grows with the covertext too. Use `python benchmark.py --help` for all options.
 
 ## References
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -25,7 +25,11 @@ Unlike standard encryption that produces random-looking output, FTE produces cip
 pip install fte
 ```
 
-Works out of the box with pure Python, no compilation required.
+libfte itself is pure Python. It depends on `cryptography` (AES-CTR on
+OpenSSL; it ships prebuilt wheels with OpenSSL bundled) and `regex2dfa` (pure
+Python), so no compiler or system library is needed on the platforms
+`cryptography` publishes wheels for. Format-preserving encryption needs the
+optional extra: `pip install 'fte[fpe]'`.
 
 ## Quick Example
 
@@ -38,19 +42,35 @@ import fte
 key = os.urandom(32)  # 32 bytes, shared by both endpoints
 
 # Pick a covertext format, then build a cipher over it and the key.
-word_format = fte.RegexFormat(r'^([a-z]+ )+[a-z]+$', length=80)
+# 73 characters of words hold up to 15 plaintext bytes (cipher.max_plaintext_bytes).
+word_format = fte.RegexFormat(r'^([a-z]+ )+[a-z]+$', length=73)
 cipher = fte.FTE(output_format=word_format, key=key)
 
 ciphertext = cipher.encrypt(b'Attack at dawn')
 print(ciphertext.decode())
-# → "a kgxbpxy vpgdigzczzkwlgmapocgjzspnqzilpyhezdbtxalonocvhlpc bbtflzgxhjjjpvmmnvvu"
+# One real run; the exact text varies per call, because the cipher is randomized:
+# aa migbcjfbkvhczkjjwogvkpr m hnczwlthnujcutvnxqtrfhfnvnjhowaax mg nazfkrf
 
 plaintext = cipher.decrypt(ciphertext)
 # → b'Attack at dawn'
 ```
 
+The covertext is a string of the chosen format that carries your encrypted
+message. Because the format holds one byte more than the message needs, the
+covertext can begin with a short run of the format's lowest-ranked symbols
+(`a` and space); a much larger `length` would make that run long.
+
 `RegexFormat` also takes a `min_length`/`max_length` range for variable-length
 covertext; a fixed `length` is the special case where they are equal.
+
+**Format-preserving and deterministic FTE.** `cipher="ff1"` (NIST SP 800-38G
+FF1 via [libffx](https://github.com/kpdyer/libffx); `pip install 'fte[fpe]'`)
+is deterministic and zero-expansion: pass the same format as `input_format`
+and `output_format` to re-encrypt a value in place (FPE, length preserved), or
+two different formats for a deterministic rank map between them. It refuses an
+input domain below one million values, is unauthenticated, and leaks plaintext
+equality, so pass per-record `tweak` values and never reuse a key across the
+two ciphers.
 
 ### Ranked-Format Providers
 
@@ -86,7 +106,8 @@ assert cipher.decrypt(covertext) == b"secret"
 The key and exact ranked-format ordering must match at both endpoints. Generic
 FTE framing exposes plaintext length through the rank and guarantees membership
 in the format's language, not a uniform distribution over unused format
-capacity.
+capacity: a fixed-length covertext much larger than the message begins with a
+run of the format's lowest-ranked symbols.
 
 ## Use Cases
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,41 @@ not receive backported patches, so please upgrade to a supported version.
 | 0.4.x   | :white_check_mark: |
 | < 0.4   | :x:                |
 
+## Security model
+
+- **Authenticated encryption** (`cipher="aes-ctr-hmac"`, the default for a
+  bytes input): AES-128-CTR, then HMAC-SHA256 over the nonce and ciphertext
+  truncated to a 128-bit tag (Encrypt-then-MAC). The 32-byte key is split into
+  a 16-byte AES key and a 16-byte MAC key. Each message gets a fresh 12-byte
+  nonce from `os.urandom`; the frame is
+  `version (1) || nonce (12) || ciphertext || tag (16)`.
+- **Nonce bound**: keep the number of messages per key well under 2^32. At
+  2^32 messages the probability of a repeated nonce is about 2^-33, and a
+  repeat exposes the confidentiality of the colliding pair only, never
+  authenticity.
+- **Decryption order**: `decrypt` rejects a covertext outside the format, an
+  impossible rank or length, or a wrong version byte before the tag check, then
+  verifies the tag (constant-time compare) before decrypting anything. The
+  pre-tag rejection timing reveals only what is computable without the key. Do
+  not expose `decrypt` to untrusted callers as a timing oracle.
+- **Deterministic cipher** (`cipher="ff1"` or a cipher object): deterministic
+  and unauthenticated. Equal plaintexts give equal covertexts, so it leaks
+  plaintext equality unless each record gets a distinct `tweak`, and it has no
+  integrity protection. Domains below one million values are refused (per
+  length slice when length is preserved). Never reuse a key across the two
+  ciphers.
+- **Patterns and lengths are trusted input**: never build a `RegexFormat` from
+  attacker-controlled values. The ranking table takes O(states x length^2)
+  memory, and the DFA state count can be exponential in the pattern.
+- **Covertext format is not a secret**: `rank`/`unrank` need no key, so anyone
+  can re-encode a covertext from one output format into another. This is
+  inherent to FTE; the key protects the plaintext and (with AE) integrity, not
+  the choice of format. With a bytes input the frame length also reveals the
+  plaintext length.
+- **Wire format**: 0.4.x covertexts are not compatible with 0.3.x and earlier,
+  which used a different construction and frame layout; both endpoints must
+  run 0.4.x.
+
 ## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues,

--- a/benchmark.py
+++ b/benchmark.py
@@ -2,15 +2,19 @@
 # -*- coding: utf-8 -*-
 """Benchmark suite for libfte (Format-Transforming Encryption).
 
-libfte is pure Python, and this script measures the two costs that matter
+libfte's ranking engine is pure Python, and this script measures the two costs that matter
 when you use it:
 
   1. Cipher construction:  the one-time cost of compiling a regex into a
      DFA and pre-computing the ranking tables. Paid once per (regex, length).
   2. encrypt() / decrypt(): the steady-state cost paid per message. This is
      dominated by the DFA rank/unrank on large integers, so it grows with the
-     covertext ``length``, not with the plaintext size.
+     covertext ``length`` (the DFA walk) and with the plaintext size (the
+     magnitude of the integer being ranked): a payload that fills the format's
+     capacity can cost several times (up to ~10x) more than a short one.
 
+To show both ends of that range, every format is timed with a short 18-byte
+payload and with a full-capacity payload (``cipher.max_plaintext_bytes``).
 It runs across a range of output formats (binary, hex, words, URLs, ...) and
 also sweeps the covertext ``length`` for one format to show how per-message
 cost scales. Every timed round-trip is verified, so a clean run also doubles as
@@ -48,8 +52,9 @@ FORMATS = [
 LENGTH_SWEEP_REGEX = r"^[a-z]+$"
 LENGTH_SWEEP_VALUES = [128, 256, 512, 1024, 2048]
 
-# Kept short so it fits every fixed-length format above; per-message cost scales
-# with the covertext length, not with the plaintext size.
+# Kept short so it fits every fixed-length format above. Per-message cost also
+# depends on the payload size, so each format is timed with this payload and
+# with one that fills its capacity (see _full_payload).
 SAMPLE_PAYLOAD = b"benchmark payload."
 
 # Fixed key; its value does not affect timing.
@@ -80,7 +85,7 @@ def _cpu_model():
 
 def _print_machine_header():
     print("=" * 76)
-    print("libfte benchmark (pure Python)")
+    print("libfte benchmark (pure-Python ranking, OpenSSL AES/HMAC)")
     print("=" * 76)
     print(f"CPU     : {_cpu_model()}")
     print(f"Arch    : {platform.machine()}")
@@ -108,18 +113,18 @@ def _median_ms(fn, iterations):
 def _bench_build(regex, length, iterations):
     """Median time to construct a cipher (regex -> DFA -> counting table)."""
     def build():
-        fte.FTE(format=fte.RegexFormat(regex, length=length), key=BENCH_KEY)
+        fte.FTE(output_format=fte.RegexFormat(regex, length=length), key=BENCH_KEY)
     return _median_ms(build, iterations)
 
 
-def _bench_format(label, regex, length, payload, iterations, warmup):
-    """Benchmark one cipher: build, encrypt, decrypt, and verify the round-trip."""
-    build_ms = _bench_build(regex, length, max(3, iterations // 5))
+def _full_payload(cipher):
+    """A deterministic payload of exactly ``cipher.max_plaintext_bytes`` bytes."""
+    n = cipher.max_plaintext_bytes
+    return (bytes(range(256)) * (n // 256 + 1))[:n]
 
-    fmt = fte.RegexFormat(regex, length=length)
-    cipher = fte.FTE(format=fmt, key=BENCH_KEY)
-    capacity = fmt.cardinality.bit_length() - 1  # floor(log2(cardinality))
 
+def _bench_round_trip(cipher, payload, iterations, warmup):
+    """Median encrypt / decrypt time for one payload, plus a round-trip check."""
     # Correctness: the whole benchmark is meaningless if the round-trip is wrong.
     ok = cipher.decrypt(cipher.encrypt(payload)) == payload
 
@@ -130,6 +135,25 @@ def _bench_format(label, regex, length, payload, iterations, warmup):
     encrypt_ms = _median_ms(lambda: cipher.encrypt(payload), iterations)
     ct = cipher.encrypt(payload)
     decrypt_ms = _median_ms(lambda: cipher.decrypt(ct), iterations)
+    return ok, encrypt_ms, decrypt_ms
+
+
+def _bench_format(label, regex, length, payload, iterations, warmup):
+    """Benchmark one cipher: build, then encrypt / decrypt a small payload and
+    a full-capacity payload, verifying both round-trips."""
+    build_ms = _bench_build(regex, length, max(3, iterations // 5))
+
+    fmt = fte.RegexFormat(regex, length=length)
+    cipher = fte.FTE(output_format=fmt, key=BENCH_KEY)
+    capacity = fmt.cardinality.bit_length() - 1  # floor(log2(cardinality))
+
+    full = _full_payload(cipher)
+    small_ok, encrypt_ms, decrypt_ms = _bench_round_trip(
+        cipher, payload, iterations, warmup
+    )
+    full_ok, full_encrypt_ms, full_decrypt_ms = _bench_round_trip(
+        cipher, full, iterations, warmup
+    )
 
     return {
         "label": label,
@@ -139,7 +163,10 @@ def _bench_format(label, regex, length, payload, iterations, warmup):
         "build_ms": build_ms,
         "encrypt_ms": encrypt_ms,
         "decrypt_ms": decrypt_ms,
-        "ok": ok,
+        "full_bytes": len(full),
+        "full_encrypt_ms": full_encrypt_ms,
+        "full_decrypt_ms": full_decrypt_ms,
+        "ok": small_ok and full_ok,
     }
 
 
@@ -147,10 +174,26 @@ def _bench_format(label, regex, length, payload, iterations, warmup):
 # Rendering                                                                    #
 # --------------------------------------------------------------------------- #
 
+# Per-message columns: the small payload (SAMPLE_PAYLOAD) and the
+# full-capacity payload (``max(B)`` bytes, the cipher's max_plaintext_bytes).
+_MESSAGE_HEADER = (
+    f"{'enc/small':>11}{'dec/small':>11}"
+    f"{'max(B)':>8}{'enc/max':>10}{'dec/max':>10}"
+)
+
+
+def _format_message_cells(r):
+    return (
+        f"{r['encrypt_ms']:>11.3f}{r['decrypt_ms']:>11.3f}"
+        f"{r['full_bytes']:>8}{r['full_encrypt_ms']:>10.3f}"
+        f"{r['full_decrypt_ms']:>10.3f}"
+    )
+
+
 def _print_format_table(rows):
     header = (
         f"{'Format':<14}{'length':>8}{'cap(bits)':>11}{'bits/char':>11}"
-        f"{'build(ms)':>12}{'encrypt(ms)':>13}{'decrypt(ms)':>13}"
+        f"{'build(ms)':>12}" + _MESSAGE_HEADER
     )
     print(header)
     print("-" * len(header))
@@ -158,18 +201,16 @@ def _print_format_table(rows):
         print(
             f"{r['label']:<14}{r['length']:>8}{r['capacity']:>11}"
             f"{r['bits_per_char']:>11.2f}{r['build_ms']:>12.3f}"
-            f"{r['encrypt_ms']:>13.3f}{r['decrypt_ms']:>13.3f}"
+            + _format_message_cells(r)
         )
 
 
 def _print_sweep_table(rows):
-    header = (f"{'length':<8}{'cap(bits)':>11}"
-              f"{'encrypt(ms)':>13}{'decrypt(ms)':>13}")
+    header = f"{'length':<8}{'cap(bits)':>11}" + _MESSAGE_HEADER
     print(header)
     print("-" * len(header))
     for r in rows:
-        print(f"{r['length']:<8}{r['capacity']:>11}"
-              f"{r['encrypt_ms']:>13.3f}{r['decrypt_ms']:>13.3f}")
+        print(f"{r['length']:<8}{r['capacity']:>11}" + _format_message_cells(r))
 
 
 # --------------------------------------------------------------------------- #
@@ -200,11 +241,13 @@ def main(argv=None):
 
     _print_machine_header()
     print()
-    print(f"Payload : {len(payload)} bytes")
-    print(f"Timing  : median of {iterations} iterations ({warmup} warmup)")
+    print(f"Payloads: small = {len(payload)} bytes; max = the format's full "
+          f"capacity (max_plaintext_bytes)")
+    print(f"Timing  : median of {iterations} iterations ({warmup} warmup); "
+          f"times in ms")
     print()
 
-    print("Per-format performance")
+    print("Per-format performance (per-message times in ms)")
     rows = [
         _bench_format(label, regex, length, payload, iterations, warmup)
         for label, regex, length in FORMATS

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -3,7 +3,12 @@
 `fte.FTE` separates cryptography from covertext generation at one narrow
 boundary: a non-negative integer rank. libfte owns encryption, authentication,
 versioned byte framing, and bytes-to-integer conversion. A format provider owns
-only the reversible mapping between ranks and canonical covertext values.
+only the reversible mapping between ranks and canonical values.
+
+A format can sit on either side of the engine: as the `output_format` (the
+covertext language) or as the `input_format` (the plaintext language, which
+defaults to `fte.BytesFormat`, raw bytes). The engine is
+`rank_in -> transform -> unrank_out`, so one provider serves both roles.
 
 ## Terminology
 
@@ -35,9 +40,28 @@ class RankedFormat(Protocol[T]):
 
 This is a structural protocol. Providers do not inherit from libfte, register
 plugins, or import libfte at runtime. An existing object with compatible methods
-already conforms. `cardinality` is optional; when supplied, it must be the exact
-positive size of the contiguous rank space `range(cardinality)`. libfte uses it
-to reject messages that cannot always fit before performing encryption.
+already conforms. Three optional conventions extend it:
+
+- `cardinality`: the exact positive size of the contiguous rank space
+  `range(cardinality)`. It is optional for the output of the `aes-ctr-hmac`
+  cipher, where libfte uses it to reject messages that cannot always fit before
+  performing encryption. The deterministic cipher requires it on both formats
+  and refuses a format without one at construction with
+  `FormatCapacityError: the deterministic cipher requires both formats to be
+  finite (expose a positive cardinality)`.
+- `fingerprint`: a stable `bytes` identifier for the exact ordering. The
+  deterministic cipher requires it on both formats (`ValueError: the
+  deterministic cipher requires both formats to expose a bytes fingerprint`),
+  binds it into every tweak, and infers FPE from equal fingerprints. Equal
+  fingerprints must guarantee identical ranking; the converse is not required
+  (`RegexFormat` hashes the pattern text, so two spellings of one language get
+  different fingerprints), so use the same spelling at both endpoints.
+- `slice_bounds(length) -> (offset, count)`, together with integer
+  `min_length` and `max_length` attributes: the first rank of the words of
+  `length` bytes and how many there are (possibly zero). When an equal-format
+  pair provides these, the deterministic cipher permutes each length slice in
+  place so a value keeps its length; `FTE.preserve_length` is inferred from
+  them, never requested.
 
 ## Required behavior
 
@@ -53,10 +77,17 @@ A provider must satisfy all of these rules:
 7. The ordering is a wire-level compatibility contract. Both endpoints must
    use implementations with identical ranking behavior.
 
-`unrank()` failures during encryption become `fte.FormatCapacityError`. Invalid
-values or failures during ranking become `fte.InvalidCovertextError`. Returning
-a non-integer or negative rank is a provider bug and raises
-`fte.FormatContractError`. Original provider exceptions are retained as causes.
+With the `aes-ctr-hmac` cipher, `unrank()` failures during encryption become
+`fte.FormatCapacityError`. On the deterministic path the cipher's output is
+always inside the output domain, so an `unrank()` failure there is a contract
+violation and propagates as raised. Invalid values or failures while ranking a
+covertext become `fte.InvalidCovertextError`; a plaintext the input format
+cannot rank, or whose rank falls outside `range(cardinality)`, becomes
+`fte.InvalidPlaintextError`. Returning a non-integer or negative rank for a
+covertext is a provider bug and raises `fte.FormatContractError` (on the input
+side the same defect is reported as `fte.InvalidPlaintextError`), as does a
+`cardinality` that is not a positive integer. Original provider exceptions are
+retained as causes.
 
 ## Example provider
 
@@ -81,8 +112,9 @@ Use it without an adapter:
 ```python
 from fte import FTE
 
-cipher = FTE(format=LowerHex(), key=shared_32_byte_key)
-covertext = cipher.encrypt(b"hello")
+shared_32_byte_key = bytes(range(32))  # demo only; use a real shared secret
+cipher = FTE(output_format=LowerHex(), key=shared_32_byte_key)
+covertext = cipher.encrypt(b"hello")   # lowercase hex; differs per run (nonce)
 assert cipher.decrypt(covertext) == b"hello"
 ```
 
@@ -91,20 +123,76 @@ unset it is derived: a finite provider (one exposing `cardinality`) uses the
 exact size its capacity allows, and an unbounded provider falls back to a 1 MiB
 default. That same limit is the guard that lets decryption reject an oversized
 rank before converting it back into a potentially large byte string, so set it
-explicitly only to tighten that bound or to cap an unbounded provider.
+explicitly only to tighten that bound or to cap an unbounded provider. It is a
+bytes-input knob: with a non-bytes `input_format` the argument is rejected
+(`ValueError`), and the property reports the serialization size of the
+input's largest rank (or `None` for the deterministic cipher).
 
-The version-one frame is variable length. Anyone who can rank a covertext can
-therefore infer its exact plaintext byte length without knowing the key. The
-mapping guarantees membership in the format's language, but it is not uniform
-over unused rank capacity when a finite provider is much larger than the
-message requires. Applications needing length hiding or a target distribution
-must add an appropriate fixed-size record/padding layer before `FTE.encrypt`.
+The version-one frame is variable length for a bytes input. Anyone who can rank
+a covertext can therefore infer its exact plaintext byte length without knowing
+the key. The mapping guarantees
+membership in the format's language, but it is not uniform over unused rank
+capacity when a finite provider is much larger than the message requires.
+Applications needing length hiding or a target distribution must add an
+appropriate fixed-size record/padding layer before `FTE.encrypt`.
 
-`FTE.decrypt` is not constant-time: it rejects malformed framing, length, and
-padding before verifying the authentication tag, so rejection latency depends on
-why a value was rejected. This is safe under FTE's threat model, where an
-on-path observer sees covertext but has no decryption oracle. Do not expose
-`decrypt` directly as a remote timing oracle to untrusted callers.
+`FTE.decrypt` is not constant-time: it rejects a covertext outside the format,
+an impossible rank or length, or a wrong version byte before verifying the
+authentication tag (the version-one frame has no padding), so rejection latency
+depends on why a value was rejected. Every check made before the tag uses only
+information available without the key. This is safe under FTE's threat model,
+where an on-path observer sees covertext but has no decryption oracle. Do not
+expose `decrypt` directly as a remote timing oracle to untrusted callers.
+
+## Input formats and the deterministic cipher
+
+Any provider can also be the `input_format`. With the `aes-ctr-hmac` cipher
+(which must be spelled out for a non-bytes input; the engine only infers it for
+raw bytes) the plaintext is ranked, the rank is serialized as a byte string
+(shortlex, so its length grows with the rank), and that byte string goes
+through the same randomized, authenticated frame as a bytes plaintext.
+`max_plaintext_bytes` reports the serialized size of the largest input rank,
+and a finite output must have room for that plus the 29-byte frame or
+construction raises `FormatCapacityError`.
+
+```python
+from fte import FTE, RegexFormat
+
+digits = RegexFormat(r"^[0-9]+$", length=12)      # 10**12 values: 5 bytes
+hex128 = RegexFormat(r"^[0-9a-f]+$", length=128)
+shared_32_byte_key = bytes(range(32))             # demo only; use a real secret
+
+cipher = FTE(input_format=digits, output_format=hex128,
+             key=shared_32_byte_key, cipher="aes-ctr-hmac")
+assert cipher.max_plaintext_bytes == 5            # the largest rank needs 5
+covertext = cipher.encrypt(b"123456789012")       # 128 hex bytes; random nonce
+assert cipher.decrypt(covertext) == b"123456789012"
+```
+
+The deterministic cipher (`cipher="ff1"`, or any object with
+`encrypt_int(x, *, domain, tweak)` / `decrypt_int(y, *, domain, tweak)`) maps
+an input rank straight to an output rank with no framing and no expansion. It
+needs both formats to be finite and fingerprinted, the input cardinality must
+not exceed the output cardinality (a permutation cannot be injective
+otherwise), and the output domain must clear the one-million format-preserving
+floor or construction raises `SmallDomainError`; with inferred length
+preservation every non-empty length slice must clear it. Passing the same
+fingerprinted format on both
+sides infers `cipher="ff1"`. The cardinality check runs before libffx is
+imported, so a bare provider such as `LowerHex` is refused even without the
+`fpe` extra:
+
+```python
+import fte
+
+try:
+    fte.FTE(input_format=LowerHex(), output_format=LowerHex(),
+            key=bytes(16), cipher="ff1")
+except fte.FormatCapacityError as exc:
+    print(exc)
+# the deterministic cipher requires both formats to be finite (expose a
+# positive cardinality)
+```
 
 ## Built-in regex provider
 
@@ -116,9 +204,10 @@ exactly the same extension point:
 from fte import FTE, RegexFormat
 
 fmt = RegexFormat(r"^[0-9a-f]+$", length=96)          # fixed 96-byte covertext
-cipher = FTE(format=fmt, key=shared_32_byte_key)
+shared_32_byte_key = bytes(range(32))                 # demo only; use a secret
+cipher = FTE(output_format=fmt, key=shared_32_byte_key)
 
-covertext: bytes = cipher.encrypt(b"hello")
+covertext: bytes = cipher.encrypt(b"hello")           # differs per run (nonce)
 assert cipher.decrypt(covertext) == b"hello"
 ```
 
@@ -137,13 +226,19 @@ the language has no words in the requested length range.
 `regex2dfa` compiles the pattern to a minimized DFA, so two patterns that denote
 the same language produce byte-identical ranking: `^[ab]+$` and `^(a|b)+$`
 interoperate. The wire contract is the format (the language, the length bounds,
-and the ordering version), never the pattern's spelling.
+and the ordering version), never the pattern's spelling. `RegexFormat` also
+exposes `fingerprint`, `slice_bounds`, `min_length`, and `max_length`, so it
+works on either side of the engine and, used on both, infers the deterministic
+cipher with in-place length preservation.
 
 ## Provider checklist
 
 - Test both inverse laws at representative and boundary ranks.
 - Test rejection of noncanonical values and unsupported ranks.
 - Document the native covertext type and ordering compatibility version.
+- Expose `cardinality` and a stable bytes `fingerprint` if the format will be
+  used with the deterministic cipher; add `slice_bounds` plus `min_length` /
+  `max_length` for in-place length preservation.
 - Document practical size, time, memory, and concurrency limits.
 - Bound work performed while ranking attacker-controlled values.
 - Keep transport framing and streaming outside the ranked-format object.

--- a/examples/09_authenticated_fte.py
+++ b/examples/09_authenticated_fte.py
@@ -5,8 +5,8 @@
 This is the authenticated row of the 2x2: the wire-frozen AES-CTR + HMAC path.
 ``aes-ctr-hmac`` is randomized and authenticated -- encrypting the same
 plaintext twice yields two different covertexts, and any tampering is detected
-on decrypt. That safety costs a fixed 33-byte frame (a version byte, IV,
-message counter, and MAC).
+on decrypt. That safety costs a fixed 29-byte frame: a version byte, a 12-byte
+random nonce, and a 16-byte HMAC-SHA256 tag (Encrypt-then-MAC over AES-128-CTR).
 
 Here the input is a structured (non-bytes) format -- a 12-digit decimal string --
 re-encrypted as hex. This uses only the built-in engine, no extra dependency.
@@ -20,7 +20,7 @@ as the ``ff1`` format-preserving cipher from the optional libffx integration).
 import os
 
 import fte
-from fte.core import FormatCapacityError, InvalidCovertextError
+from fte import FormatCapacityError, InvalidCovertextError
 
 
 def main():
@@ -68,7 +68,7 @@ def main():
     except FormatCapacityError:
         print(
             "In-place aes-ctr-hmac (same format both sides) is refused at construction: "
-            "the 33-byte frame does not fit -- use ff1 for that."
+            "the 29-byte frame does not fit in 12 digits -- use ff1 for that."
         )
 
     print("\nSuccess! Authenticated FTE round-trips and rejects tampering.")

--- a/examples/11_deterministic_fte.py
+++ b/examples/11_deterministic_fte.py
@@ -21,7 +21,7 @@ Requires the optional libffx extra::
 import os
 
 import fte
-from fte.core import InvalidCovertextError
+from fte import InvalidCovertextError
 
 
 def main():

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ This directory contains examples demonstrating various features of the libfte li
 
 ```bash
 pip install fte
+pip install 'fte[fpe]'   # examples 10 and 11: the ff1 cipher needs libffx
 ```
 
 ## Examples
@@ -40,11 +41,18 @@ import os
 import fte
 
 key = os.urandom(32)  # 32-byte key, shared by both endpoints
-cipher = fte.FTE(output_format=fte.RegexFormat('^[0-9a-f]+$', length=128), key=key)
+# 87 hex characters hold up to 15 plaintext bytes (cipher.max_plaintext_bytes).
+cipher = fte.FTE(output_format=fte.RegexFormat('^[0-9a-f]+$', length=87), key=key)
 
 ciphertext = cipher.encrypt(b'secret message')
+# One real run; the hex varies per call, because the cipher is randomized:
+# b'0020c129212fbb36e83cffb0d6f0626e86a38e62ab581f0c1aad2fe45226f187f3f067423f94ce8cf3b030f'
 plaintext = cipher.decrypt(ciphertext)
 ```
+
+A `length` far above what the message needs makes the covertext start with a
+long run of the format's lowest symbol (leading zeros here); see
+[How It Works](../README.md#how-it-works) in the main README.
 
 To target a covertext language no regex denotes, supply your own
 `RankedFormat` (see `08_custom_format.py`).
@@ -56,7 +64,8 @@ README for how alphabet size drives capacity.
 
 ## Tips
 
-1. **Larger `length`** = more capacity but longer covertext
+1. **Larger `length`** = more capacity but longer covertext, and a longer
+   leading run of the lowest-ranked symbol when the message is small
 2. **A larger alphabet in the pattern** = more bits per character
 3. **A fixed-`length` covertext is exactly `length` bytes**, so a stream of
    them slices into fixed-size chunks; a `min_length`/`max_length` covertext

--- a/fte/formats/__init__.py
+++ b/fte/formats/__init__.py
@@ -8,8 +8,8 @@ subpackage to copy for a new provider.
 
     >>> import fte
     >>> from fte.formats import RegexFormat
-    >>> cipher = fte.FTE(format=RegexFormat(r"^[0-9a-f]+$", length=96),
-    ...                  key=bytes(range(32)))
+    >>> cipher = fte.FTE(output_format=RegexFormat(r"^[0-9a-f]+$", length=96),
+    ...                  key=b"0123456789abcdef" * 2)  # demo key; 32 bytes
 """
 
 from fte.formats.base import RankedFormat

--- a/fte/formats/regex/README.md
+++ b/fte/formats/regex/README.md
@@ -11,15 +11,22 @@ paths, lowercase words, and so on.
 ```python
 import fte
 
-# Every covertext is exactly 128 bytes of lowercase hex.
+# Every covertext is exactly 72 bytes of lowercase hex.
 cipher = fte.FTE(
-    format=fte.RegexFormat(r'^[0-9a-f]+$', length=128),
+    output_format=fte.RegexFormat(r'^[0-9a-f]+$', length=72),
     key=bytes(range(32)),               # demo key; share a real secret
 )
 
-covertext = cipher.encrypt(b'secret')   # e.g. '9f3c...'  (128 hex chars)
+covertext = cipher.encrypt(b'secret')
+# 72 hex chars, different on every run (the frame carries a random nonce), e.g.
+# b'00029c3526a6938e1c4d94eaa379c2f5380e9aa1ec1a82e114df39e9bbe953862b57b18b'
 assert cipher.decrypt(covertext) == b'secret'
 ```
+
+The leading zeros are the format's spare capacity: the frame for a 6-byte
+message is a little smaller than the largest 72-digit hex number, so the top
+digits come out zero. A message closer to `cipher.max_plaintext_bytes` fills
+them.
 
 ## Fixed vs variable length
 
@@ -43,11 +50,12 @@ Pass either `length`, or the `min_length`/`max_length` pair, not both.
 
 ## Choosing a length
 
-The covertext has to be big enough to hold FTE's authenticated frame (a fixed
-33-byte overhead plus the message). If the format is too small for even an
-empty message, `fte.FTE(...)` raises `FormatCapacityError` at construction. As a
-rule of thumb, capacity grows with the alphabet size and the length: for the hex
-format above, `length=128` holds up to 31 plaintext bytes
+The covertext has to be big enough to hold FTE's authenticated frame: a fixed
+29-byte overhead (1 version byte, a 12-byte random nonce, and a 16-byte
+HMAC-SHA256 tag) plus the message. If the format is too small for even an empty
+message, `fte.FTE(...)` raises `FormatCapacityError` at construction. As a rule
+of thumb, capacity grows with the alphabet size and the length: the hex format
+above holds up to 7 plaintext bytes at `length=72` and 35 at `length=128`
 (`cipher.max_plaintext_bytes`). Construction also raises `ValueError` if the
 language has no words in the requested length range.
 

--- a/fte/formats/regex/format.py
+++ b/fte/formats/regex/format.py
@@ -167,9 +167,11 @@ class RegexFormat:
         """Stable identifier for this pattern and length range.
 
         ``sha256(b"fte:regex:1|" + pattern + b"|" + min_length + b"|" +
-        max_length)``, with the lengths in decimal UTF-8. Two ``RegexFormat``
-        instances share a fingerprint exactly when they rank identically,
-        which is what the deterministic engine relies on.
+        max_length)``, with the lengths in decimal UTF-8. It hashes the
+        pattern *text*, so equal fingerprints guarantee identical ranking
+        (which is what the deterministic engine relies on), but two spellings
+        of one language get different fingerprints; use the same pattern
+        string at both endpoints of a deterministic cipher.
         """
 
         return self._fingerprint

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -157,9 +157,10 @@ class Tests(unittest.TestCase):
             cipher.encrypt(b"123456")
 
     def test_finite_format_too_small_is_rejected_at_construction(self):
-        # length=8 hex holds 16**8 == 2**32 values, far too few for the 33-byte
-        # authenticated frame, so the format cannot hold even an empty message
-        # and building an FTE around it fails fast.
+        # length=8 hex holds 16**8 == 2**32 values, far too few for the 29-byte
+        # authenticated frame (1 version byte + 12-byte nonce + 16-byte tag),
+        # so the format cannot hold even an empty message and building an FTE
+        # around it fails fast.
         with self.assertRaises(fte.FormatCapacityError):
             fte.FTE(output_format=fte.RegexFormat(r"^[0-9a-f]+$", length=8), key=KEY)
 


### PR DESCRIPTION
Documentation-only PR (plus the `benchmark.py` script). No library behaviour changes. Describes the code as it is on `master` today.

## What changed
- **Crypto description**: README said HMAC-SHA512 and a 33-byte frame; the code is AES-128-CTR + HMAC-SHA256 (128-bit tag) with a 29-byte frame (1 version + 12 nonce + 16 tag). Fixed in README, the regex README, examples/09, and a test comment.
- **Stale kwarg**: `FTE(format=...)` raises `TypeError`; docs/formats.md, the regex README, the `fte.formats` docstring (a failing doctest), and `benchmark.py` (which crashed) now use `output_format=`.
- **Real example outputs**: the shown covertexts were fictional; each snippet now uses the smallest `length` that fits its message and shows one genuine run, with the leading-symbol run explained in How It Works.
- **API reference**: adds `fte.BytesFormat`, `RegexFormat.fingerprint` / `slice_bounds`, and an Exceptions table; docs/formats.md covers input formats, fingerprints, `slice_bounds`, `InvalidPlaintextError`, and drops the mention of padding (the frame has none). The fingerprint contract is stated accurately: equal fingerprints guarantee identical ranking, but two spellings of one language get different fingerprints.
- **SECURITY.md** gains a security-model section; **BUILDING.md** and **README_PYPI.md** describe the compiled `cryptography` dependency and the `fpe` extra honestly; PyPI readme mentions `cipher="ff1"`.
- **benchmark.py** also measures a full-capacity payload (per-message cost depends on payload size, which its docstring denied). LICENSE year 2026.

## Verification
Full suite, doctests, all 11 examples, all 18 runnable doc code blocks, and `benchmark.py --quick` pass on this branch.

Two follow-up PRs are stacked on this one because their doc paragraphs sit inside regions this PR rewrites: the RegexFormat syntax guard and the core engine changes. They retarget to `master` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
