### PR TITLE
ci/packaging: PEP 639 metadata, fpe extra in CI, gated Dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       github-actions:
         patterns:
           - "*"
+        # The PyPI publish action receives the trusted-publishing OIDC token
+        # and is never exercised by CI, so it always arrives as its own PR
+        # for human review instead of riding along in the group.
+        exclude-patterns:
+          - "pypa/gh-action-pypi-publish"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,13 +19,31 @@ jobs:
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Only patch and minor bumps are approved and merged unattended. Major
+      # bumps can change an action's or a package's behaviour, and
+      # pypa/gh-action-pypi-publish receives the PyPI trusted-publishing OIDC
+      # token and is never exercised by CI, so those need a human review.
       - name: Approve pull request
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
         run: gh pr review --approve "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 
       - name: Enable auto-merge
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          !contains(steps.metadata.outputs.dependency-names, 'pypa/gh-action-pypi-publish')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,fpe]"
 
       - name: Run tests
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include docs/formats.md
 recursive-include fte *.md
 graft tests
 prune tests/__pycache__
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-# >=64 for PEP 660 editable installs without a setup.py shim.
-requires = ["setuptools>=64"]
+# >=77 for PEP 639 license metadata (license = "MIT" + license-files); that
+# also covers PEP 660 editable installs without a setup.py shim (>=64).
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,17 +9,20 @@ name = "fte"
 dynamic = ["version"]
 description = "Format-Transforming Encryption"
 readme = "README_PYPI.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
     {name = "Kevin P. Dyer", email = "kpdyer@gmail.com"}
 ]
-keywords = ["cryptography", "encryption", "regex", "DFA", "FTE"]
+keywords = [
+    "cryptography", "encryption", "regex", "DFA", "FTE", "FPE",
+    "format-preserving",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/test_ff1_integration.py
+++ b/tests/test_ff1_integration.py
@@ -1,10 +1,9 @@
 """Integration tests for the real deterministic cipher (``cipher="ff1"``).
 
-These exercise :class:`fte.FTE` against the genuine
-format-preserving cipher from libffx. That package is being built in parallel
-and is not importable here, so the whole module skips via
-``pytest.importorskip("ffx")``; the engine mechanics themselves are covered
-without ffx in ``test_engine_matrix.py``.
+These exercise :class:`fte.FTE` against the genuine format-preserving cipher
+from libffx (``pip install 'fte[fpe]'``, which CI installs). Without it the
+whole module skips via ``pytest.importorskip("ffx")``; the engine mechanics
+themselves are covered without ffx in ``test_engine_matrix.py``.
 """
 
 import unittest


### PR DESCRIPTION
CI and packaging only. No library code changes.

## What changed
- **PEP 639**: `license = "MIT"` + `license-files`, the MIT classifier dropped, `setuptools>=77` for the build. `python -m build` no longer prints deprecation warnings; the wheel carries `License-Expression: MIT`.
- **MANIFEST.in**: `global-exclude *.py[cod]`. A local build after a test run shipped `tests/regex_corpus/__pycache__/*.pyc` in the sdist.
- **CI installs `.[dev,fpe]`**: libffx 2.0.0 is on PyPI, so `tests/test_ff1_integration.py` now runs in the matrix instead of skipping everywhere. Job names are unchanged (branch protection depends on them).
- **Dependabot gating**: the auto-merge workflow approved and merged every Dependabot PR, majors included, and the grouped actions bump covered `pypa/gh-action-pypi-publish`, which receives the trusted-publishing OIDC token and is never exercised by CI. The publish action is now excluded from the group so it arrives alone, and the workflow uses `dependabot/fetch-metadata` (SHA-pinned, v2.5.0) to approve and auto-merge only `semver-patch` / `semver-minor` PRs that do not touch it.

## Verification
Full suite passes (ff1 tests included), both YAML files parse, sdist and wheel build cleanly and pass `twine check`, the sdist contains no bytecode.

Note: requiring at least one approving review on `master` is a branch-protection setting in the GitHub UI, not something this repo can set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
