### PR TITLE
perf(dfa): run-grouped transitions for non-dense states in rank/unrank

### DIFF
--- a/fte/formats/regex/dfa.py
+++ b/fte/formats/regex/dfa.py
@@ -10,7 +10,10 @@ The algorithm is based on:
 - "Protocol Misidentification Made Easy with Format-Transforming Encryption"
 """
 
-from typing import Dict, FrozenSet, List, NamedTuple, Set, Tuple, Union
+from itertools import groupby
+from typing import (
+    Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Union,
+)
 
 __all__ = [
     "DFA",
@@ -20,6 +23,16 @@ __all__ = [
     "InvalidRankInput",
     "InvalidUnrankInput",
 ]
+
+# A non-dense state takes the run-grouped rank/unrank path only when its
+# transitions collapse into at most ``1 / _RUN_PATH_DIVISOR`` as many runs as
+# there are alphabet symbols. Each run costs roughly twice what one symbol
+# costs in the per-symbol walk (tuple unpack, bound check, multiply), so the
+# grouping only pays off when it removes most of the iterations; at ratios
+# near one (2-symbol alphabets, states whose neighbours all differ) the plain
+# per-symbol walk stays ahead. Measured break-even: rank at a runs/symbols
+# ratio of about 0.4, unrank at about 0.9; one third keeps both ahead.
+_RUN_PATH_DIVISOR = 3
 
 
 class InvalidFSTFormat(Exception):
@@ -135,6 +148,11 @@ class DFA:
         dfa_str: A minimized AT&T FST formatted DFA string, or a
             :class:`ParsedFst`.
         length: The maximum word length the counting table supports.
+
+    Raises:
+        InvalidFSTFormat: If the string does not parse (see
+            :func:`parse_att_fst`) or the alphabet has a symbol outside the
+            byte range 0..255.
     """
 
     def __init__(self, dfa_str: Union[str, ParsedFst], length: int):
@@ -148,8 +166,13 @@ class DFA:
         self._symbols: List[int] = list(parsed.symbols)
         self._final_states: Set[int] = set(parsed.final_states)
         self._sigma_reverse: Dict[int, int] = {}  # symbol byte value -> index
+        self._symbol_index: List[int] = []        # byte value -> index or -1
         self._delta: List[List[int]] = []         # transition table
         self._delta_dense: List[bool] = []        # all-transitions-equal flag
+        # Per state: runs of consecutive symbols sharing a destination, as
+        # (next_state, first_symbol_idx, count) triples in symbol order, or
+        # None when rank/unrank should walk that state symbol by symbol.
+        self._runs: List[Optional[List[Tuple[int, int, int]]]] = []
         self._T: List[List[int]] = []             # counting table
 
         self._build_delta(parsed.transitions)
@@ -173,6 +196,18 @@ class DFA:
         self._sigma_reverse = {
             symbol: idx for idx, symbol in enumerate(self._symbols)
         }
+        # Same map as a 256-entry list so rank can index by byte value
+        # instead of calling ``dict.get`` for every symbol. That fixes the
+        # alphabet to byte values: a larger symbol would not fit the list and
+        # a negative one would silently alias another entry.
+        for symbol in self._symbols:
+            if not 0 <= symbol <= 255:
+                raise InvalidFSTFormat(
+                    f"symbol {symbol} is outside the byte range 0..255"
+                )
+        self._symbol_index = [-1] * 256
+        for symbol, idx in self._sigma_reverse.items():
+            self._symbol_index[symbol] = idx
 
         # Initialize delta (transition table) to dead state
         self._delta = [
@@ -197,19 +232,26 @@ class DFA:
             self._T[q][0] = 1
             prev_col[q] = 1
 
-        # Collapse each state's transitions into (next_state, count) pairs and
-        # split states by how many distinct destinations they have. Most states
-        # send *every* symbol to a single destination (e.g. every letter in
-        # ``[a-z]`` leads to the same next state), so those reduce to one
-        # ``count * T[next_state]`` multiply, replacing a run of identical
-        # big-integer additions. Partitioning up front keeps that common
-        # single-destination path free of any per-state branching.
+        # Group each state's transitions into runs of consecutive symbols that
+        # share a destination, collapse those into (next_state, count) pairs,
+        # and split states by how many distinct destinations they have. Most
+        # states send *every* symbol to a single destination (e.g. every
+        # letter in ``[a-z]`` leads to the same next state), so those reduce
+        # to one ``count * T[next_state]`` multiply, replacing a run of
+        # identical big-integer additions. Partitioning up front keeps that
+        # common single-destination path free of any per-state branching.
+        # States with few runs relative to the alphabet (a literal or wildcard
+        # in a 256-symbol alphabet) keep their run list so rank and unrank can
+        # step over each run in one multiply; see ``_RUN_PATH_DIVISOR``.
         single = []   # (q, next_state, count)
         multi = []    # (q, [(next_state, count), ...])
+        max_runs = len(self._symbols) // _RUN_PATH_DIVISOR
         self._delta_dense = [False] * num_states
+        self._runs = [None] * num_states
         for q in range(num_states):
+            row = self._delta[q]
             counts: Dict[int, int] = {}
-            for next_state in self._delta[q]:
+            for next_state in row:
                 counts[next_state] = counts.get(next_state, 0) + 1
             if len(counts) == 1:
                 # A "dense" state sends every symbol to one destination; rank
@@ -217,8 +259,20 @@ class DFA:
                 self._delta_dense[q] = True
                 (next_state, count), = counts.items()
                 single.append((q, next_state, count))
-            else:
-                multi.append((q, list(counts.items())))
+                continue
+            multi.append((q, list(counts.items())))
+            # A state has at least as many runs as destinations, so only
+            # states that can pass the run threshold pay for the grouping.
+            if len(counts) > max_runs:
+                continue
+            runs: List[Tuple[int, int, int]] = []
+            start = 0
+            for next_state, group in groupby(row):
+                count = len(list(group))
+                runs.append((next_state, start, count))
+                start += count
+            if len(runs) <= max_runs:
+                self._runs[q] = runs
 
         # Fill the table column by column: T[q][i] = sum over symbols a of
         # T[delta[q][a]][i-1].
@@ -252,9 +306,13 @@ class DFA:
             The integer rank of ``X`` among accepted words of length ``len(X)``.
 
         Raises:
-            InvalidRankInput: If ``X`` is longer than ``length`` or is not in the
-                language.
+            InvalidRankInput: If ``X`` is not bytes, is longer than ``length``,
+                or is not in the language.
         """
+        if not isinstance(X, (bytes, bytearray)):
+            raise InvalidRankInput(
+                f"Input must be bytes, not {type(X).__name__}"
+            )
         if len(X) > self._length:
             raise InvalidRankInput(
                 f"Input length {len(X)} exceeds built length {self._length}"
@@ -267,7 +325,8 @@ class DFA:
         T = self._T
         delta = self._delta
         dense = self._delta_dense
-        sigma_reverse = self._sigma_reverse
+        runs = self._runs
+        symbol_index = self._symbol_index
 
         # Collect each position's contribution, then sum them smallest-first.
         # Earlier positions carry far larger weights than later ones, so adding
@@ -282,7 +341,7 @@ class DFA:
         for i in range(1, n + 1):
             byte_val = X[i - 1]
 
-            symbol_idx = sigma_reverse.get(byte_val, -1)
+            symbol_idx = symbol_index[byte_val]
             if symbol_idx < 0:
                 raise InvalidRankInput(f"Symbol {byte_val} not in alphabet")
 
@@ -293,11 +352,29 @@ class DFA:
                 # Optimized: all transitions from q go to same state
                 if symbol_idx:
                     append(T[delta_q[0]][col] * symbol_idx)
-            else:
+            elif runs[q] is None:
                 # Standard Goldberg-Sipser ranking
                 s = 0
                 for j in range(symbol_idx):
                     s += T[delta_q[j]][col]
+                if s:
+                    append(s)
+            else:
+                # Run-grouped ranking: every symbol in a run leads to the same
+                # state, so a whole run below ``symbol_idx`` contributes
+                # ``count * T[next_state][col]`` in one multiply, and the run
+                # containing ``symbol_idx`` contributes its prefix.
+                s = 0
+                for next_state, start, count in runs[q]:
+                    if start + count <= symbol_idx:
+                        v = T[next_state][col]
+                        if v:
+                            s += count * v if count > 1 else v
+                    else:
+                        k = symbol_idx - start
+                        if k:
+                            s += k * T[next_state][col]
+                        break
                 if s:
                     append(s)
 
@@ -338,17 +415,19 @@ class DFA:
             )
 
         result = bytearray()
+        append = result.append
         q = self._start_state
 
         # Hoist attribute lookups out of the per-character loop.
         T = self._T
         delta = self._delta
         dense = self._delta_dense
+        runs = self._runs
         symbols = self._symbols
 
-        for i in range(1, length + 1):
+        # Position i of the word draws on column length - i of the table.
+        for col in range(length - 1, -1, -1):
             delta_q = delta[q]
-            col = length - i
 
             if dense[q]:
                 # Optimized: all transitions from q go to same state
@@ -359,7 +438,7 @@ class DFA:
                     char_idx, c = divmod(c, divisor)
                 else:
                     char_idx = 0
-            else:
+            elif runs[q] is None:
                 # Standard Goldberg-Sipser unranking
                 char_idx = 0
                 state = delta_q[0]
@@ -369,10 +448,32 @@ class DFA:
                     char_idx += 1
                     state = delta_q[char_idx]
                     threshold = T[state][col]
+            else:
+                # Run-grouped unranking: skip whole runs whose block of
+                # ``count`` equal thresholds lies below ``c``, then locate the
+                # symbol inside the absorbing run with a single divmod.
+                for state, start, count in runs[q]:
+                    threshold = T[state][col]
+                    if not threshold:
+                        continue
+                    block = count * threshold if count > 1 else threshold
+                    if c >= block:
+                        c -= block
+                        continue
+                    if count > 1:
+                        k, c = divmod(c, threshold)
+                        char_idx = start + k
+                    else:
+                        char_idx = start
+                    break
+                else:
+                    # Unreachable: the range check above guarantees that the
+                    # blocks of some run absorb ``c``.
+                    raise InvalidUnrankInput("Rank not absorbed by any run")
 
-            result.append(symbols[char_idx])
-            # In both branches ``state`` is delta[q][char_idx], so it is the
-            # next state regardless of density.
+            append(symbols[char_idx])
+            # In every branch ``state`` is delta[q][char_idx], so it is the
+            # next state regardless of which walk produced it.
             q = state
 
         # Verify we ended in a final state

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -5,6 +5,7 @@ contract (per-length rank/unrank, counting, and input validation) worth testing
 directly.
 """
 
+import random
 import unittest
 
 import regex2dfa
@@ -65,6 +66,35 @@ class Tests(unittest.TestCase):
         dfa = build(r"^[01]+$", 4)
         with self.assertRaises(InvalidRankInput):
             dfa.rank(b"01\xff1")  # 0xff is not in the {0, 1} alphabet
+
+    def test_rank_rejects_non_bytes(self):
+        dfa = build(r"^[01]+$", 4)
+        for bad in ("0101", [0x30, 0x31], 0x30, None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(InvalidRankInput):
+                    dfa.rank(bad)
+        # A bytearray is bytes-like and ranks the same as its bytes.
+        self.assertEqual(dfa.rank(bytearray(b"0101")), dfa.rank(b"0101"))
+
+    def test_symbol_outside_byte_range_is_rejected(self):
+        # The alphabet indexes a fixed 256-entry table: a symbol above 255
+        # cannot be stored and a negative one would alias another entry.
+        for symbol in (256, 300, -1):
+            with self.subTest(symbol=symbol):
+                with self.assertRaisesRegex(InvalidFSTFormat, "0..255"):
+                    DFA(f"0\t1\t{symbol}\t{symbol}\n1\n", 2)
+                parsed = ParsedFst(
+                    start_state=0,
+                    final_states=frozenset({1}),
+                    transitions=((0, 1, symbol),),
+                    symbols=(symbol,),
+                )
+                with self.assertRaisesRegex(InvalidFSTFormat, "0..255"):
+                    DFA(parsed, 2)
+        # The byte-range edges are fine.
+        dfa = DFA("0\t1\t0\t0\n0\t1\t255\t255\n1\n", 1)
+        self.assertEqual(dfa.unrank(0, 1), b"\x00")
+        self.assertEqual(dfa.unrank(1, 1), b"\xff")
 
     def test_rank_rejects_non_accepting_word(self):
         # ``^(0|1)[a-z]+$``: a leading digit must be followed by letters. A
@@ -139,6 +169,68 @@ class Tests(unittest.TestCase):
                 self.assertEqual(dfa.rank(word), index)
         self.assertEqual(dfa.unrank(0, 3), b"000")
         self.assertEqual(dfa.rank(b"111"), 7)
+
+    def test_run_grouped_states_match_per_symbol_reference(self):
+        # ``^.*abc$`` over the 256-byte alphabet: every state sends most bytes
+        # to a fallback state and one or two literal bytes elsewhere, so its
+        # transitions group into a handful of runs (one state has five: a
+        # long run, three single bytes, another long run) and rank/unrank
+        # take the run-grouped walk. The expected ranks were computed with
+        # the per-symbol reference implementation.
+        dfa = build(r"^.*abc$", 16)
+        self.assertTrue(any(runs is not None for runs in dfa._runs))
+        self.assertEqual(
+            dfa.num_words(16), 20282409603651670423947251286016
+        )
+        expected = {
+            b"\x00" * 13 + b"abc": 0,
+            b"aaaaaaaaaaaaaabc": 7715269535506713847540719116641,
+            b"abcabcabcabcxabc": 7715581438386765282237680345976,
+            b"hello, worldaabc": 8271117963530313756381553648737,
+            b"~~~~~~~~~~~~~abc": 10021896510039648915362171223678,
+        }
+        for word, index in expected.items():
+            self.assertEqual(dfa.rank(word), index)
+            self.assertEqual(dfa.unrank(index, 16), word)
+        rng = random.Random(16)
+        count = dfa.num_words(16)
+        for index in [0, 1, count - 2, count - 1] + [
+            rng.randrange(count) for _ in range(100)
+        ]:
+            self.assertEqual(dfa.rank(dfa.unrank(index, 16)), index)
+        with self.assertRaises(InvalidRankInput):
+            dfa.rank(b"a" * 16)         # walks run states, never accepts
+        with self.assertRaises(InvalidUnrankInput):
+            dfa.unrank(count, 16)
+
+    def test_mixed_run_and_per_symbol_states_roundtrip(self):
+        # ``^([ac]x|[bd]y)+$`` over the alphabet {a, b, c, d, x, y}: the start
+        # state alternates destinations (five runs, walked per symbol) while
+        # the state after b/d has only two runs (walked by run), so one word
+        # crosses both code paths. Expected ranks come from the per-symbol
+        # reference implementation.
+        dfa = build(r"^([ac]x|[bd]y)+$", 8)
+        self.assertTrue(any(runs is not None for runs in dfa._runs))
+        self.assertEqual(dfa.num_words(8), 256)
+        expected = {
+            b"axaxaxax": 0,
+            b"byaxcxdy": 75,
+            b"cxbydyax": 156,
+            b"dydydydy": 255,
+        }
+        for word, index in expected.items():
+            self.assertEqual(dfa.rank(word), index)
+            self.assertEqual(dfa.unrank(index, 8), word)
+        for index in range(256):
+            word = dfa.unrank(index, 8)
+            self.assertEqual(len(word), 8)
+            self.assertEqual(dfa.rank(word), index)
+        with self.assertRaises(InvalidRankInput):
+            dfa.rank(b"axaxaxaa")       # ends in a non-accepting state
+        with self.assertRaises(InvalidRankInput):
+            dfa.rank(b"axaxaxaz")       # 'z' is outside the alphabet
+        with self.assertRaises(InvalidUnrankInput):
+            dfa.unrank(256, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Performance only; output is byte-identical.

## Change
For a state whose transitions are not dense, `rank()` summed one table entry per symbol below the input symbol and `unrank()` subtracted one threshold at a time: O(alphabet) big-int operations per position, paid on most positions of any pattern with literals or wildcards. Construction now groups each qualifying state's transitions into runs of consecutive symbols with the same destination, and rank/unrank do one multiply-add or one block subtraction plus divmod per run. Dense states keep the existing fast path; the run path is used only where it wins.

Also: an AT&T FST symbol outside 0..255 raises `InvalidFSTFormat` instead of indexing past the new 256-entry symbol table, and `rank()` keeps raising `InvalidRankInput` for a non-bytes input.

## Evidence
- Every corpus golden passes unchanged (the golden file is not touched).
- An independent old-vs-new harness agreed on rank, unrank, round-trip, and `num_words` for all corpus entries plus adversarial shapes.
- Measured per-message gains of 2.5x to 18x on literal/wildcard patterns (`^.*abcdefgh$`: 561 → 35 µs rank), within noise on dense shapes such as `^[a-z]+$`; construction time within a few percent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
