### PR TITLE
RegexFormat: reject regex syntax that regex2dfa silently misreads (re-land of #95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,23 @@ fte.RegexFormat(pattern: str, *, min_length: int, max_length: int)  # range
 
 `length=N` is shorthand for `min_length=max_length=N`; pass either `length` or
 the `min_length`/`max_length` pair, not both. Construction raises `ValueError`
-if the language has no words in the requested length range.
+if the language has no words in the requested length range, if the pattern is
+not a valid regular expression, or if it uses syntax that regex2dfa would
+silently misread. The pattern always matches the whole covertext, and the
+dialect is smaller than Python's `re` (literals, `*` `+` `?`, `|`, `(...)`,
+classes with ranges and `^` negation, `.` for any of the 256 bytes, the escapes
+`\n` `\t` `\r` `\0` `\xHH` `\d` `\s` `\w`, and a backslash before any
+punctuation character). Rejected up front: brace quantifiers (`{3}`, `{2,4}`:
+any unescaped `{` outside a class; write `\{` or `[{]` for a literal brace);
+every other backslash-letter or backslash-digit escape (`\D` `\S` `\W` `\b`
+`\B` `\A` `\Z` `\z` `\f` `\v` `\a` `\e` `\u...` `\p{...}` `\Q...\E`,
+backreferences `\1`..`\9`, and so on); octal escapes (`\012`) and `\x` without
+exactly two hex digits; a backslash anywhere inside `[...]` (`[\d]`, `[\n]`,
+`[\]]`, `[\\]`); an empty class `[]` or `[^]`; POSIX classes (`[[:alpha:]]`);
+`^` or `$` anywhere but the start or end of the pattern or of an alternative;
+empty alternatives (`(a|)`; write `(a)?`) and empty groups `()`; and a pattern
+ending in a bare backslash or in `\$` (write `\$$` or `[$]`). See
+[`fte/formats/regex/README.md`](fte/formats/regex/README.md) for the full list.
 
 ### `fte.BytesFormat`
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -223,6 +223,15 @@ length arguments are missing, mixed, or not positive integers with
 `min_length <= max_length`; if `pattern` is not a valid regular expression; or if
 the language has no words in the requested length range.
 
+Construction also raises `ValueError`, before `regex2dfa` runs, for syntax that
+`regex2dfa` would silently misread rather than reject: brace quantifiers such
+as `{3}` or `{2,4}` (write `\{` or `[{]` for a literal brace), escapes it does
+not implement (`\D`, `\S`, `\W`, `\b`, backreferences, octal escapes, `\x`
+without exactly two hex digits), a backslash anywhere inside `[...]`, an empty
+or POSIX class, empty alternatives and empty groups, and `^` or `$` away from
+the start or end of the pattern or of an alternative. [`fte/formats/regex/README.md`](../fte/formats/regex/README.md)
+lists the supported dialect in full.
+
 `regex2dfa` compiles the pattern to a minimized DFA, so two patterns that denote
 the same language produce byte-identical ranking: `^[ab]+$` and `^(a|b)+$`
 interoperate. The wire contract is the format (the language, the length bounds,

--- a/fte/formats/regex/README.md
+++ b/fte/formats/regex/README.md
@@ -59,6 +59,69 @@ above holds up to 7 plaintext bytes at `length=72` and 35 at `length=128`
 (`cipher.max_plaintext_bytes`). Construction also raises `ValueError` if the
 language has no words in the requested length range.
 
+## Supported syntax
+
+`RegexFormat` hands the pattern to `regex2dfa`, whose dialect is smaller than
+Python's `re`. The pattern always describes the whole covertext (there is no
+unanchored search), and the alphabet is bytes: `.` means any of the 256 byte
+values, newline included. Everything below was verified against the DFAs
+regex2dfa emits.
+
+Supported:
+
+- Literal characters. A character in U+0080..U+00FF stands for the byte of the
+  same value; anything above raises `ValueError` (patterns denote byte
+  languages).
+- The quantifiers `*`, `+`, `?`; alternation `|`; groups `(...)`, nested and
+  quantified (`(ab)+`).
+- Character classes `[abc]`, ranges `[a-z]`, several ranges `[a-cx-z]`, negated
+  classes `[^a]`, and a literal `-` at either end (`[-a]`, `[a-]`). Punctuation
+  is literal inside a class, `[{}$.*|(]` included.
+- The escapes `\n`, `\t`, `\r`, `\0` (NUL), `\xHH` (exactly two hex digits),
+  `\d` (`[0-9]`), `\w` (`[0-9A-Za-z_]`), and `\s` (tab, newline, carriage
+  return, space; not `\v` or `\f`), plus a backslash before any punctuation
+  character for that literal character (`\.`, `\\`, `\{`, `\$`, ...).
+- `^` at the start and `$` at the end of the pattern or of an alternative
+  (`^a$|^b$`). They are optional: `a`, `^a`, `a$`, and `^a$` denote the same
+  language.
+
+Rejected by `RegexFormat` with `ValueError` before compilation, because
+regex2dfa would silently misread them (as literal text, or by dropping or
+rebinding them):
+
+- Brace quantifiers `{n}`, `{n,m}`, `{n,}`, `{,m}`: any unescaped `{` outside a
+  class. Write `\{` or `[{]` for a literal brace; `}` on its own is fine.
+- Every other backslash-letter or backslash-digit escape: `\D`, `\S`, `\W`,
+  `\b`, `\B`, `\A`, `\Z`, `\f`, `\v`, `\a`, `\e`, `\u...`, `\p{...}`,
+  `\Q...\E`, backreferences `\1`..`\9`, and so on. regex2dfa does not support
+  them (it compiles most to the bare letter or digit, and `\C` to any byte).
+  Spell the class out instead (`[^0-9]` for `\D`).
+- Octal escapes (`\012`) and `\x` with fewer than two hex digits.
+- A backslash inside a character class (`[\d]`, `[\n]`, `[\]]`, `[\\]`):
+  regex2dfa has no escapes inside `[...]`, so the backslash is a literal
+  backslash and the first `]` still closes the class. Write the escape outside
+  the class, or put the actual character in the string (`'[\t ]'` in a non-raw
+  Python string).
+- An empty class `[]` or `[^]` (the first `]` always closes the class), and
+  POSIX classes like `[[:alpha:]]`.
+- `^` or `$` anywhere but the start or end of the pattern or of an alternative
+  (`^a$b$`): regex2dfa drops them. Write `\^` or `[$]` for the literal
+  character. A `\$` at the very end of the pattern is rejected too: regex2dfa
+  strips the final `$` before parsing, and the dangling backslash would become
+  a NUL byte. Write `\$$` or `[$]` instead. A pattern ending in a bare
+  backslash is rejected for the same reason.
+- Empty alternatives (`a|`, `|a`, `a||b`, `(|a)`, `(a|)`): regex2dfa rejects
+  most of them, but one right before `)` silently folds the atom before the
+  group into the alternation (`x(b|)y` becomes `(x|b)y`). Write `?` after a
+  group for an optional group (`x(b)?y`).
+- An empty group `()`: regex2dfa applies a quantifier after it to the
+  preceding atom instead (`a()*` becomes `a*`).
+
+regex2dfa rejects the rest itself, and `RegexFormat` reports that as
+`ValueError` too: lazy and possessive quantifiers (`a+?`, `a*+`), every `(?...)`
+form (non-capturing groups, flags, lookaround, named groups), unclosed classes,
+reversed ranges, and patterns denoting the empty language (`^$`).
+
 ## What's in here
 
 - [`format.py`](format.py): `RegexFormat`, the provider. Its whole job is the two

--- a/fte/formats/regex/format.py
+++ b/fte/formats/regex/format.py
@@ -40,8 +40,181 @@ def _positive_int(name: str, value: object) -> int:
     return value
 
 
+# The backslash-letter escapes regex2dfa implements (checked against the DFAs
+# it emits). ``\x`` is handled separately because it takes two hex digits.
+# Every other backslash-letter or backslash-digit pair is compiled to the bare
+# letter or digit, so the scanner below rejects it instead.
+_ESCAPES = frozenset("ntr0dsw")
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _check_pattern_syntax(pattern: str) -> None:
+    """Reject syntax that regex2dfa would silently misread.
+
+    regex2dfa raises its own error for lazy quantifiers, ``(?...)`` groups and
+    malformed patterns, but it reads several other constructs as plain text
+    (or drops them) rather than reporting them. This single left-to-right pass
+    catches those before compilation; see the ``RegexFormat`` docstring and
+    ``fte/formats/regex/README.md`` for the dialect it enforces.
+    """
+
+    for i, c in enumerate(pattern):
+        if ord(c) > 0xFF:
+            raise ValueError(
+                f"character {c!r} (U+{ord(c):04X}) at position {i} in "
+                f"{pattern!r} is not a byte: patterns denote byte languages, "
+                "so every character must be in U+0000..U+00FF"
+            )
+
+    n = len(pattern)
+    i = 0
+    prev = ""  # the previous significant character, "" after escapes/classes
+    # Whether the current alternative (since the pattern start, the last '('
+    # or the last '|') has no atom yet, and which of those opened it.
+    empty_alt = True
+    alt_start = ""
+    while i < n:
+        c = pattern[i]
+        if c == "\\":
+            # An escape pair: the backslash and the character it protects.
+            esc = pattern[i + 1 : i + 2]
+            if esc == "" or (esc == "$" and i + 2 == n):
+                # regex2dfa strips a final '$' before parsing, so a pattern
+                # ending in '\' or '\$' leaves a dangling backslash that it
+                # compiles to a NUL byte.
+                raise ValueError(
+                    f"pattern {pattern!r} ends in a dangling backslash: "
+                    "regex2dfa strips the final '$' first and compiles what "
+                    "is left to a NUL byte; write '\\$$' or '[$]' for a "
+                    "literal '$'"
+                )
+            if esc == "x":
+                digits = pattern[i + 2 : i + 4]
+                if len(digits) != 2 or not set(digits) <= _HEX_DIGITS:
+                    raise ValueError(
+                        f"'\\x' at position {i} in {pattern!r} needs exactly "
+                        "two hex digits: regex2dfa reads a shorter one at "
+                        "the end of the pattern as a different byte"
+                    )
+                i += 4
+                prev = ""
+                empty_alt = False
+                continue
+            if esc == "0" and pattern[i + 2 : i + 3] in tuple("0123456789"):
+                raise ValueError(
+                    f"regex2dfa has no octal escapes: {pattern[i:i + 3]!r} "
+                    f"in {pattern!r} is a NUL byte followed by the literal "
+                    f"digit {pattern[i + 2]!r}; write '\\xHH' instead"
+                )
+            if esc.isascii() and esc.isalnum() and esc not in _ESCAPES:
+                raise ValueError(
+                    f"regex2dfa does not implement the escape "
+                    f"{pattern[i:i + 2]!r} at position {i} in {pattern!r}: "
+                    "it is unsupported and would not mean what it means in "
+                    "Python's re (the supported escapes are \\n \\t \\r \\0 "
+                    "\\xHH \\d \\s \\w and a backslash before punctuation)"
+                )
+            i += 2
+            prev = ""
+            empty_alt = False
+            continue
+        if c == "[":
+            # A character class. regex2dfa has no escapes inside one (a
+            # backslash is a literal backslash) and the first ']' always
+            # closes it, so '[]' is empty and '[\]]' is not what it looks like.
+            start = i + 2 if pattern.startswith("[^", i) else i + 1
+            end = pattern.find("]", start)
+            if end == -1:
+                break  # unclosed: regex2dfa reports it
+            body = pattern[start:end]
+            if not body:
+                raise ValueError(
+                    f"regex2dfa closes a character class at the first ']', "
+                    f"so {pattern[i:end + 1]!r} at position {i} in "
+                    f"{pattern!r} is an empty class; write '\\]' outside a "
+                    "class for a literal ']'"
+                )
+            if "\\" in body:
+                raise ValueError(
+                    f"regex2dfa has no escapes inside a character class: the "
+                    f"backslash in {pattern[i:end + 1]!r} at position {i} in "
+                    f"{pattern!r} is a literal backslash and ']' still closes "
+                    "the class; write the escape outside the class or list "
+                    "the characters directly"
+                )
+            if "[:" in body:
+                raise ValueError(
+                    f"regex2dfa has no POSIX classes: '[:' in "
+                    f"{pattern[i:end + 1]!r} at position {i} in {pattern!r} "
+                    "would be matched literally; write the range out instead "
+                    "(e.g. '[A-Za-z]')"
+                )
+            i = end + 1
+            prev = "]"
+            empty_alt = False
+            continue
+        if c == "{":
+            raise ValueError(
+                f"regex2dfa has no brace quantifiers: '{{' at position {i} "
+                f"in {pattern!r} would be matched literally; write '\\{{' "
+                "or '[{]' for a literal brace"
+            )
+        # Anchors are meaningful only at the start or end of the pattern or
+        # of an alternative; regex2dfa silently ignores them anywhere else.
+        if c == "^" and i > 0 and prev not in ("(", "|", "^"):
+            raise ValueError(
+                f"regex2dfa ignores '^' in the middle of a pattern (position "
+                f"{i} in {pattern!r}; every pattern is matched in full); "
+                "write '\\^' for a literal caret"
+            )
+        if c == "$" and i + 1 < n and pattern[i + 1] not in ")|$":
+            raise ValueError(
+                f"regex2dfa ignores '$' in the middle of a pattern (position "
+                f"{i} in {pattern!r}; every pattern is matched in full); "
+                "write '[$]' for a literal dollar sign"
+            )
+        # Empty alternatives and empty groups. regex2dfa rejects most empty
+        # alternatives itself, but one right before ')' silently folds the
+        # atom before the group into the alternation ('x(b|)y' becomes
+        # '(x|b)y'), and a quantifier after '()' silently binds to the
+        # preceding atom ('a()*' becomes 'a*').
+        if c == "(":
+            empty_alt = True
+            alt_start = "("
+        elif c == "|":
+            if empty_alt:
+                raise ValueError(_empty_alternative(pattern, i))
+            empty_alt = True
+            alt_start = "|"
+        elif c == ")":
+            if empty_alt and alt_start == "|":
+                raise ValueError(_empty_alternative(pattern, i))
+            if empty_alt:
+                raise ValueError(
+                    f"empty group '()' at position {i - 1} in {pattern!r}: "
+                    "regex2dfa applies a quantifier after it to the "
+                    "preceding atom instead ('a()*' becomes 'a*')"
+                )
+            empty_alt = False
+        elif c not in "^$":
+            empty_alt = False
+        i += 1
+        prev = c
+    if empty_alt and alt_start == "|":
+        raise ValueError(_empty_alternative(pattern, n))
+
+
+def _empty_alternative(pattern: str, i: int) -> str:
+    return (
+        f"empty alternative at position {i} in {pattern!r}: regex2dfa "
+        "rejects most of these and silently rewrites the language for one "
+        "before ')' ('x(b|)y' becomes '(x|b)y'); write '?' after a group "
+        "for an optional group"
+    )
+
+
 class RegexFormat:
-    """A ranked byte format compiled from a regular expression.
+    r"""A ranked byte format compiled from a regular expression.
 
     Every covertext matches ``pattern`` and has a length in
     ``[min_length, max_length]``. The rank space is ``range(cardinality)``, where
@@ -69,9 +242,30 @@ class RegexFormat:
     Raises:
         TypeError: If ``pattern`` is not a string.
         ValueError: If the length arguments are missing, mixed, or not positive
-            integers with ``min_length <= max_length``; if ``pattern`` is not a
-            valid regular expression; or if the language has no words in the
-            requested length range.
+            integers with ``min_length <= max_length``; if ``pattern`` has a
+            character above U+00FF (patterns denote byte languages); if it
+            uses syntax regex2dfa would silently misread (a brace quantifier
+            such as ``{3}``, an escape it does not implement such as ``\D``,
+            a backslash inside ``[...]``, a mid-pattern ``^`` or ``$``, an
+            empty alternative or an empty group ``()``; see the note below);
+            if ``pattern`` is otherwise not a valid regular expression
+            (including one denoting the empty language, such as ``^$``); or
+            if the language has no words in the requested length range.
+
+    Note:
+        **Supported syntax.** The pattern goes to ``regex2dfa``, whose dialect
+        is smaller than Python's ``re`` and always matches the whole
+        covertext. Supported: literal characters, the quantifiers ``*`` ``+``
+        ``?``, alternation ``|``, groups ``(...)``, character classes with
+        ranges and ``^`` negation, ``.`` for any of the 256 bytes, the escapes
+        ``\n`` ``\t`` ``\r`` ``\0`` ``\xHH`` ``\d`` ``\s`` ``\w``, and a
+        backslash before any punctuation character for that literal character
+        (so ``\{`` or ``[{]`` is a literal brace). Brace quantifiers, other
+        letter or digit escapes, escapes inside ``[...]``, ``^``/``$`` away
+        from the edges of the pattern or of an alternative, empty
+        alternatives (``a|``, ``(a|)``) and empty groups (``()``) are
+        rejected up front because regex2dfa would misread them. See
+        ``fte/formats/regex/README.md`` for the full list.
 
     Example:
         >>> fmt = RegexFormat(r"^[0-9a-f]+$", length=96)
@@ -79,6 +273,12 @@ class RegexFormat:
         True
         >>> fmt.unrank(fmt.rank(fmt.unrank(0))) == fmt.unrank(0)
         True
+        >>> RegexFormat(r"^\{[0-9]+\}$", length=4).unrank(0)
+        b'{00}'
+        >>> RegexFormat(r"^[0-9]{3}$", length=3)  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        ValueError: regex2dfa has no brace quantifiers: ...
     """
 
     __slots__ = (
@@ -122,13 +322,16 @@ class RegexFormat:
         else:
             raise ValueError("provide length, or min_length and max_length")
 
+        _check_pattern_syntax(pattern)
         try:
-            dfa_str = regex2dfa.regex2dfa(pattern)
-        except Exception as exc:  # regex2dfa raises its own parser errors
+            # regex2dfa raises its own parser errors; the DFA rejects an
+            # automaton with no symbols, which is what an empty-language
+            # pattern such as '^$' compiles to.
+            dfa = DFA(regex2dfa.regex2dfa(pattern), hi)
+        except Exception as exc:
             raise ValueError(
                 f"invalid regular expression: {pattern!r}"
             ) from exc
-        dfa = DFA(dfa_str, hi)
 
         # Order the language's slice by length first, then lexicographically
         # within a length. Record where each length starts in the combined rank
@@ -194,6 +397,8 @@ class RegexFormat:
     def rank(self, value: bytes, /) -> int:
         """Return the rank of a canonical covertext ``value``."""
 
+        if not isinstance(value, (bytes, bytearray)):
+            raise TypeError("value must be bytes")
         n = len(value)
         if n < self.min_length or n > self.max_length:
             raise ValueError(

--- a/tests/regex_corpus/regex_corpus_data.py
+++ b/tests/regex_corpus/regex_corpus_data.py
@@ -12,7 +12,9 @@ up to several thousand, and alphabets from 2 to 256 symbols (the ``dfa_*``
 entries), so the general ranking walk is exercised, not just flat languages.
 
 regex2dfa quirks the patterns respect: no ``{n}``/``{n,m}`` quantifiers
-(braces are literal), no ``\\x`` escapes; ``.`` means any of 256 bytes.
+(``RegexFormat`` rejects brace quantifiers, since regex2dfa would read the
+braces literally), ``\\xHH`` escapes are supported, and ``.`` means any of
+256 bytes.
 """
 
 from __future__ import annotations
@@ -116,7 +118,6 @@ CORPUS: list[tuple[str, str, object, list[str]]] = [
     ('dot_plus_short', '^.+$', 4, ['dot', 'b256']),
     ('explicit_3', '^[a-z][a-z][a-z]$', 3, ['explicit', 'fixed']),
     ('explicit_mixed', '^[a-z][0-9][a-z]$', 3, ['explicit', 'fixed']),
-    ('union_empty_branch', '^(a|)b$', (1, 2), ['optional-alt', 'edge']),
     ('deep_nest', '^((ab)|(cd)|(ef))+$', 8, ['union', 'nested']),
     ('alt_star', '^(a*b)+$', 8, ['star', 'nested', 'skew']),
     ('plus_of_opt', '^(ab?)+$', 8, ['optional', 'loop', 'skew']),
@@ -177,5 +178,5 @@ CORPUS: list[tuple[str, str, object, list[str]]] = [
     ('dfa_varloop', '^(ab|cde|fghi|jklmn)+$', (2, 12), ['dfa', 'loop', 'varlen']),
 ]
 
-assert len(CORPUS) == 150
-assert len({e[0] for e in CORPUS}) == 150  # unique ids
+assert len(CORPUS) == 149
+assert len({e[0] for e in CORPUS}) == 149  # unique ids

--- a/tests/regex_corpus/regex_corpus_golden.json
+++ b/tests/regex_corpus/regex_corpus_golden.json
@@ -7295,23 +7295,6 @@
    ]
   ]
  },
- "union_empty_branch": {
-  "cardinality": "1",
-  "dfa": {
-   "alphabet": 2,
-   "states": 3,
-   "transitions": 2
-  },
-  "max_length": 2,
-  "min_length": 1,
-  "pattern": "^(a|)b$",
-  "probes": [
-   [
-    "0",
-    "6162"
-   ]
-  ]
- },
  "union_nested": {
   "cardinality": "1048576",
   "dfa": {

--- a/tests/regex_corpus/test_regex_corpus.py
+++ b/tests/regex_corpus/test_regex_corpus.py
@@ -1,10 +1,11 @@
-"""Regression suite over the 100-regex edge-case corpus.
+"""Regression suite over the 149-regex edge-case corpus.
 
-The corpus (``corpus.py``) plus its frozen goldens (``corpus_golden.json``) pin
-the exact ranking bijection of every edge-case regex. Any change that alters a
-cardinality, an ``unrank`` output, or the ``rank`` inverse fails here, so a
-performance optimization cannot silently change the wire format. Regenerate the
-goldens with ``gen_corpus_golden.py`` only when such a change is intentional.
+The corpus (``regex_corpus_data.py``) plus its frozen goldens
+(``regex_corpus_golden.json``) pin the exact ranking bijection of every
+edge-case regex. Any change that alters a cardinality, an ``unrank`` output, or
+the ``rank`` inverse fails here, so a performance optimization cannot silently
+change the wire format. Regenerate the goldens with
+``gen_regex_corpus_golden.py`` only when such a change is intentional.
 
 Coverage per regex: cardinality, sampled ``unrank`` outputs and their ``rank``
 inverses (all frozen), out-of-range boundaries, length bounds, an independent
@@ -56,7 +57,7 @@ def _format_for(label: str) -> RegexFormat:
 
 
 def test_corpus_size_and_unique_ids():
-    assert len(CORPUS) == 150
+    assert len(CORPUS) == 149
     assert len(_IDS) == len(set(_IDS))
 
 

--- a/tests/test_regex_format.py
+++ b/tests/test_regex_format.py
@@ -68,6 +68,39 @@ class Tests(unittest.TestCase):
         with self.assertRaises(ValueError):
             fte.RegexFormat(r"^(ab", length=4)  # unbalanced parenthesis
 
+    def test_empty_language_pattern_is_value_error(self):
+        # These compile to an automaton with no symbols; the DFA's own error
+        # must surface as ValueError, chained from the original.
+        from fte.formats.regex.dfa import InvalidFSTFormat
+
+        for pattern in ("", "^", "$", "^$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(
+                    ValueError, "invalid regular expression"
+                ) as cm:
+                    fte.RegexFormat(pattern, length=1)
+                self.assertIsInstance(cm.exception.__cause__, InvalidFSTFormat)
+        # '()' is rejected by the scanner before compilation.
+        with self.assertRaises(ValueError):
+            fte.RegexFormat("()", length=1)
+
+    def test_non_latin1_character_is_value_error(self):
+        # Patterns denote byte languages; a character above U+00FF has no byte.
+        for pattern in ("^€$", "^😀$", "^[a-z€]$", "^a|😀$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "U\\+0000..U\\+00FF"):
+                    fte.RegexFormat(pattern, length=1)
+        # U+00FF itself is the byte 0xff.
+        self.assertEqual(fte.RegexFormat("^\xff$", length=1).unrank(0), b"\xff")
+
+    def test_rank_rejects_non_bytes(self):
+        fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=4)
+        for bad in ("abcd", [0x61] * 4, 0x61, None):
+            with self.subTest(bad=bad):
+                with self.assertRaises(TypeError):
+                    fmt.rank(bad)
+        self.assertEqual(fmt.rank(bytearray(b"abcd")), fmt.rank(b"abcd"))
+
     def test_empty_language_for_range_is_value_error(self):
         with self.assertRaises(ValueError):
             fte.RegexFormat(r"^(ab)+$", length=5)  # no words of odd length
@@ -147,6 +180,151 @@ class Tests(unittest.TestCase):
                 value = fmt.unrank(index)
                 self.assertIsNotNone(matcher.fullmatch(value))
                 self.assertEqual(fmt.rank(value), index)
+
+    # ------------------------------------------------------------------ #
+    # Syntax regex2dfa would silently misread                            #
+    # ------------------------------------------------------------------ #
+
+    def test_brace_quantifier_is_rejected(self):
+        # regex2dfa has no brace quantifiers: it would match '{3}' literally.
+        for pattern in (r"^[0-9]{3}$", r"^[0-9]{2,4}$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "brace quantifier"):
+                    fte.RegexFormat(pattern, length=4)
+
+    def test_escaped_brace_is_a_literal_brace(self):
+        self.assertEqual(fte.RegexFormat(r"^\{$", length=1).unrank(0), b"{")
+        self.assertEqual(fte.RegexFormat(r"^[{]$", length=1).unrank(0), b"{")
+        # '}' on its own needs no escape.
+        self.assertEqual(fte.RegexFormat(r"^a}$", length=2).unrank(0), b"a}")
+
+    def test_escaped_backslash_before_brace_is_rejected(self):
+        # r"\\{" is an escaped backslash followed by an unescaped brace.
+        with self.assertRaisesRegex(ValueError, "brace quantifier"):
+            fte.RegexFormat(r"^\\{$", length=2)
+
+    def test_negated_class_escapes_are_rejected(self):
+        # regex2dfa compiles each of these to the bare letter.
+        for escape in (r"\D", r"\S", r"\W"):
+            with self.subTest(escape=escape):
+                with self.assertRaisesRegex(ValueError, "does not implement"):
+                    fte.RegexFormat("^" + escape + "$", length=1)
+
+    def test_anchor_and_boundary_escapes_are_rejected(self):
+        for escape in (r"\b", r"\B", r"\A", r"\Z", r"\z"):
+            with self.subTest(escape=escape):
+                with self.assertRaisesRegex(ValueError, "does not implement"):
+                    fte.RegexFormat("^a" + escape + "$", length=2)
+
+    def test_control_character_escapes_are_rejected(self):
+        for escape in (r"\f", r"\v", r"\a", r"\e"):
+            with self.subTest(escape=escape):
+                with self.assertRaisesRegex(ValueError, "does not implement"):
+                    fte.RegexFormat("^" + escape + "$", length=1)
+
+    def test_unicode_and_quoting_escapes_are_rejected(self):
+        for escape in (r"\u0041", r"\U00000041", r"\p{L}", r"\P{L}", r"\Qa\E"):
+            with self.subTest(escape=escape):
+                with self.assertRaisesRegex(ValueError, "does not implement"):
+                    fte.RegexFormat("^" + escape + "$", length=1)
+
+    def test_backreference_escape_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not implement"):
+            fte.RegexFormat(r"^(a)\1$", length=2)  # regex2dfa: literal 'a1'
+
+    def test_octal_escape_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "octal"):
+            fte.RegexFormat(r"^\012$", length=1)
+
+    def test_short_hex_escape_is_rejected(self):
+        for pattern in (r"^\x4$", r"^\x$", r"^[a-z]\x$", r"^\xg1$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "two hex digits"):
+                    fte.RegexFormat(pattern, length=2)
+
+    def test_trailing_backslash_is_rejected(self):
+        # regex2dfa strips the final '$' before parsing, so each of these
+        # would end in a dangling backslash that it compiles to a NUL byte.
+        for pattern in (r"^a\$", r"^a\\\$", "^a\\"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "dangling backslash"):
+                    fte.RegexFormat(pattern, length=2)
+        # An escaped '$' followed by the anchor, mid-pattern, or in a class
+        # is a literal dollar sign.
+        self.assertEqual(fte.RegexFormat(r"^a\$$", length=2).unrank(0), b"a$")
+        self.assertEqual(fte.RegexFormat(r"^a[$]$", length=2).unrank(0), b"a$")
+        self.assertEqual(fte.RegexFormat(r"^a\$b$", length=3).unrank(0), b"a$b")
+
+    def test_backslash_inside_class_is_rejected(self):
+        # Inside [...] regex2dfa reads a backslash as a literal backslash and
+        # the first ']' still closes the class.
+        for pattern in (r"^[\d]$", r"^[\n]$", r"^[\]]$", r"^[\\]$", r"^[a\-z]$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "inside a character"):
+                    fte.RegexFormat(pattern, length=1)
+
+    def test_empty_class_is_rejected(self):
+        for pattern in (r"^[]$", r"^[]a]$", r"^[^]$", r"^[^]a]$"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "empty class"):
+                    fte.RegexFormat(pattern, length=1)
+
+    def test_posix_class_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "POSIX"):
+            fte.RegexFormat(r"^[[:alpha:]]+$", length=4)
+
+    def test_mid_pattern_anchor_is_rejected(self):
+        for pattern in (r"^a$b$", r"^a^b$", r"a$b", r"a^b"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "middle of a pattern"):
+                    fte.RegexFormat(pattern, length=2)
+
+    def test_empty_alternative_is_rejected(self):
+        # regex2dfa rejects most empty alternatives itself, but one right
+        # before ')' silently folds the preceding atom into the alternation
+        # ('x(b|)y' becomes '(x|b)y'), so the scanner rejects them all.
+        for pattern in (
+            r"^x(b|)y$", r"^(a|)b$", r"^xy(a|)$", r"^(a|b|)c$",   # before ')'
+            r"^x(|b)y$", r"^(|a)b$",                              # after '('
+            r"^a||b$", r"a||b",                                   # '||'
+            r"^|ab$", r"|a", r"^$|^a$",                           # at start
+            r"^ab|$", r"a|", r"^a$|$",                            # at end
+        ):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "empty alternative"):
+                    fte.RegexFormat(pattern, min_length=1, max_length=3)
+        # The optional-group spelling is the supported one.
+        fmt = fte.RegexFormat(r"^x(b)?y$", min_length=1, max_length=3)
+        self.assertEqual(
+            {fmt.unrank(i) for i in range(fmt.cardinality)}, {b"xy", b"xby"}
+        )
+
+    def test_empty_group_is_rejected(self):
+        # regex2dfa binds a quantifier after '()' to the preceding atom.
+        for pattern in (r"^a()*$", r"^a()+$", r"^a()?$", r"^()a$", r"()"):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "empty group"):
+                    fte.RegexFormat(pattern, length=1)
+
+    def test_anchors_at_alternative_edges_are_accepted(self):
+        for pattern in (r"^a$|^b$", r"^(^a|^b)$", r"a|b", r"^a", r"a$", r"^^a$$"):
+            with self.subTest(pattern=pattern):
+                self.assertEqual(fte.RegexFormat(pattern, length=1).unrank(0), b"a")
+
+    def test_supported_escapes_compile_to_their_meaning(self):
+        self.assertEqual(
+            fte.RegexFormat(r"^\x41\n\t\r\0\.$", length=6).unrank(0),
+            b"A\n\t\r\x00.",
+        )
+        self.assertEqual(fte.RegexFormat(r"^\d$", length=1).cardinality, 10)
+        self.assertEqual(fte.RegexFormat(r"^\w$", length=1).cardinality, 63)
+        space = fte.RegexFormat(r"^\s$", length=1)
+        self.assertEqual(
+            {space.unrank(i) for i in range(space.cardinality)},
+            {b"\t", b"\n", b"\r", b" "},
+        )
+        self.assertEqual(fte.RegexFormat(r"^.$", length=1).cardinality, 256)
+        self.assertEqual(fte.RegexFormat(r"^[^a]$", length=1).cardinality, 255)
 
     # ------------------------------------------------------------------ #
     # Through the FTE engine                                             #


### PR DESCRIPTION
Re-lands #95 on `master`. #95 was merged while its base was still the `docs/accuracy-0.4.0` branch (that branch was not deleted after #93 merged, so GitHub did not retarget), so its changes landed on the docs branch instead of `master`. This PR cherry-picks that squash commit onto `master` unchanged; review already happened in #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)