### PR TITLE
FTE: fixed-width rank serialization, input-domain floor, cheap bytes-output guard (re-land of #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,20 @@ encryption + 16 MAC); `"ff1"` needs 16/24/32 and requires the extra
 A deterministic cipher infers **length preservation** from the formats: when
 input and output are the same format and it can name its per-length slices, a
 value keeps its length; otherwise the whole language is permuted. It also
-enforces a **one-million domain floor** (Draft SP 800-38G Rev 1), raising
-`SmallDomainError` on a smaller domain, with no opt-out.
+enforces a **one-million domain floor** (Draft SP 800-38G Rev 1) on the
+*input* domain, raising `SmallDomainError` with no opt-out: every non-empty
+length slice must clear it when length is preserved, and the input format's whole
+cardinality must clear it for a cross-format map (the output is at least as
+large, so it clears it too).
 
 `max_plaintext_bytes` (the `aes-ctr-hmac` cipher, bytes input) is chosen for
 you when left unset: a finite output format uses the exact size its capacity
 allows, and an unbounded one falls back to a 1 MiB default. It also lets
-`decrypt` reject an oversized covertext cheaply. It is rejected for a non-bytes
-input, whose size the format's cardinality already fixes.
+`decrypt` reject an oversized covertext cheaply. Passing it is rejected for a
+non-bytes input: there the property reports the fixed width at which every
+input rank is serialized before encryption (the smallest `W` with
+`256**W >= cardinality`), so the covertext length never depends on the
+plaintext value.
 
 ### `fte.RegexFormat`
 
@@ -301,7 +307,7 @@ size, an unknown `cipher`, an invalid pattern) raise `TypeError` or
 | `InvalidCovertextError` | `decrypt` cannot recover a plaintext: the covertext is not in the output language, is oversized, has the wrong frame version, fails authentication, or (deterministic cipher) deciphers outside the input format's rank space |
 | `InvalidPlaintextError` | `encrypt` is given a value that is not a member of a non-bytes `input_format` (its `rank()` fails or falls outside the rank space); a non-bytes plaintext for the bytes input is a `TypeError` |
 | `MessageTooLargeError` | A bytes plaintext exceeds the configured ceiling (the `max_plaintext_bytes` argument, or the 1 MiB default); exceeding a finite format's capacity is `FormatCapacityError` instead |
-| `SmallDomainError` | A deterministic cipher's domain is below the one-million floor: a non-empty length slice with fewer than a million words when length is preserved, or an output domain with fewer than a million values for a cross-format map |
+| `SmallDomainError` | A deterministic cipher's domain is below the one-million floor: a non-empty length slice with fewer than a million words when length is preserved, or an input format with fewer than a million values for a cross-format map |
 
 ## How It Works
 
@@ -318,6 +324,10 @@ size, an unknown `cipher`, an invalid pattern) raise `TypeError` or
 3. **Formatting**: A built-in or custom ranked format maps that integer to a
    covertext with `unrank()`; `decrypt()` runs the steps in reverse and
    rejects a covertext whose tag does not verify with `InvalidCovertextError`.
+
+With a non-bytes `input_format`, step 1 encrypts the input's rank serialized at
+a fixed width set by the input's cardinality, so the covertext length never
+depends on the plaintext value.
 
 The framing is variable-length. Anyone who can rank a covertext can infer its
 exact plaintext byte length, even without the key. FTE guarantees membership in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,9 +30,10 @@ not receive backported patches, so please upgrade to a supported version.
 - **Deterministic cipher** (`cipher="ff1"` or a cipher object): deterministic
   and unauthenticated. Equal plaintexts give equal covertexts, so it leaks
   plaintext equality unless each record gets a distinct `tweak`, and it has no
-  integrity protection. Domains below one million values are refused (per
-  length slice when length is preserved). Never reuse a key across the two
-  ciphers.
+  integrity protection. Domains below one million values are refused: the
+  input domain must clear the floor and the output domain must be at least as
+  large (per length slice when length is preserved). Never reuse a key across
+  the two ciphers.
 - **Patterns and lengths are trusted input**: never build a `RegexFormat` from
   attacker-controlled values. The ranking table takes O(states x length^2)
   memory, and the DFA state count can be exponential in the pattern.

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -125,12 +125,14 @@ default. That same limit is the guard that lets decryption reject an oversized
 rank before converting it back into a potentially large byte string, so set it
 explicitly only to tighten that bound or to cap an unbounded provider. It is a
 bytes-input knob: with a non-bytes `input_format` the argument is rejected
-(`ValueError`), and the property reports the serialization size of the
-input's largest rank (or `None` for the deterministic cipher).
+(`ValueError`), and the property reports the fixed serialization width
+described below (or `None` for the deterministic cipher).
 
 The version-one frame is variable length for a bytes input. Anyone who can rank
 a covertext can therefore infer its exact plaintext byte length without knowing
-the key. The mapping guarantees
+the key. (With a non-bytes `input_format` the input rank is serialized at a
+fixed width, so every frame has the same length and the covertext reveals
+nothing about the plaintext value; see below.) The mapping guarantees
 membership in the format's language, but it is not uniform over unused rank
 capacity when a finite provider is much larger than the message requires.
 Applications needing length hiding or a target distribution must add an
@@ -148,23 +150,25 @@ expose `decrypt` directly as a remote timing oracle to untrusted callers.
 
 Any provider can also be the `input_format`. With the `aes-ctr-hmac` cipher
 (which must be spelled out for a non-bytes input; the engine only infers it for
-raw bytes) the plaintext is ranked, the rank is serialized as a byte string
-(shortlex, so its length grows with the rank), and that byte string goes
-through the same randomized, authenticated frame as a bytes plaintext.
-`max_plaintext_bytes` reports the serialized size of the largest input rank,
-and a finite output must have room for that plus the 29-byte frame or
-construction raises `FormatCapacityError`.
+raw bytes) the plaintext is ranked, the rank is serialized at a fixed width
+`W`, the smallest `W` with `256**W >= cardinality`, and that byte string goes
+through the same randomized, authenticated frame as a bytes plaintext. Because
+the width is fixed by the input's `cardinality`, the frame length never depends
+on the plaintext value. `max_plaintext_bytes` reports `W`, and a finite output
+must have room for a `W + 29` byte frame or construction raises
+`FormatCapacityError`. Decryption rejects an authentic frame whose payload is
+not exactly `W` bytes.
 
 ```python
 from fte import FTE, RegexFormat
 
-digits = RegexFormat(r"^[0-9]+$", length=12)      # 10**12 values: 5 bytes
+digits = RegexFormat(r"^[0-9]+$", length=12)      # 10**12 values: W = 5
 hex128 = RegexFormat(r"^[0-9a-f]+$", length=128)
 shared_32_byte_key = bytes(range(32))             # demo only; use a real secret
 
 cipher = FTE(input_format=digits, output_format=hex128,
              key=shared_32_byte_key, cipher="aes-ctr-hmac")
-assert cipher.max_plaintext_bytes == 5            # the largest rank needs 5
+assert cipher.max_plaintext_bytes == 5            # 256**4 < 10**12 <= 256**5
 covertext = cipher.encrypt(b"123456789012")       # 128 hex bytes; random nonce
 assert cipher.decrypt(covertext) == b"123456789012"
 ```
@@ -174,10 +178,11 @@ The deterministic cipher (`cipher="ff1"`, or any object with
 an input rank straight to an output rank with no framing and no expansion. It
 needs both formats to be finite and fingerprinted, the input cardinality must
 not exceed the output cardinality (a permutation cannot be injective
-otherwise), and the output domain must clear the one-million format-preserving
+otherwise), and the input domain must clear the one-million format-preserving
 floor or construction raises `SmallDomainError`; with inferred length
-preservation every non-empty length slice must clear it. Passing the same
-fingerprinted format on both
+preservation every non-empty length slice must clear it. The floor applies to
+the input domain because the strength of a deterministic map is bounded by the
+input space, not by the key. Passing the same fingerprinted format on both
 sides infers `cipher="ff1"`. The cardinality check runs before libffx is
 imported, so a bare provider such as `LowerHex` is refused even without the
 `fpe` extra:

--- a/fte/core.py
+++ b/fte/core.py
@@ -15,12 +15,12 @@ choices shape it:
 
 That gives a 2x2 of behaviors:
 
-===============  =========================  ============================
-cipher \\ format  input == output            input != output
-===============  =========================  ============================
-``ff1`` / obj    FPE (in place)             deterministic FTE (rank map)
-``aes-ctr-hmac``           authenticated, expanding   classic bytes -> AE -> format
-===============  =========================  ============================
+================  =========================  ============================
+cipher \\ format   input == output            input != output
+================  =========================  ============================
+``ff1`` / obj     FPE (in place)             deterministic FTE (rank map)
+``aes-ctr-hmac``  authenticated, expanding   classic bytes -> AE -> format
+================  =========================  ============================
 
 The engine owns the cryptography; a format owns nothing but its ordering. See
 :mod:`fte.formats` for the provider contract.
@@ -150,13 +150,16 @@ class FTE(Generic[Plaintext, Covertext]):
     With the ``aes-ctr-hmac`` cipher the covertext is randomized and authenticated, so
     encrypting the same plaintext twice yields two different covertexts: they
     are re-drawn per call. This holds for a non-bytes input too, whose rank is
-    serialized and then run through the same randomized AE frame.
+    serialized at a fixed width (set by the input format's cardinality, so the
+    frame length never depends on the plaintext) and then run through the same
+    randomized AE frame.
 
     The deterministic (``ff1`` / object) cipher is, by contrast,
     *deterministic* and *unauthenticated*: equal plaintexts map to equal
     covertexts, so it leaks plaintext equality, and its effective strength is
-    bounded by the size of the input space rather than by the key. Pass a
-    distinct per-record ``tweak`` to separate encryptions.
+    bounded by the size of the input space rather than by the key, so the
+    one-million floor is enforced on the input domain. Pass a distinct
+    per-record ``tweak`` to separate encryptions.
     """
 
     _FRAME_VERSION = frame.FRAME_VERSION
@@ -356,12 +359,14 @@ class FTE(Generic[Plaintext, Covertext]):
         # The format-preserving floor is always enforced: FF1 is insecure over a
         # domain small enough to brute-force, so a too-small domain is refused
         # rather than made opt-outable.
+        # The strength of a deterministic map is bounded by the input space,
+        # so the floor applies to n_in (n_in <= n_out, so n_out clears it too).
         if preserve_length:
             self._check_slice_domains(_FF1_DOMAIN_FLOOR)
-        elif self._n_out < _FF1_DOMAIN_FLOOR:
+        elif self._n_in < _FF1_DOMAIN_FLOOR:
             raise SmallDomainError(
-                f"output domain {self._n_out} is below the format-preserving "
-                f"floor {_FF1_DOMAIN_FLOOR}; enlarge the format"
+                f"input domain {self._n_in} is below the format-preserving "
+                f"floor {_FF1_DOMAIN_FLOOR}; enlarge the input format"
             )
 
         # Resolve the concrete cipher object.
@@ -436,11 +441,19 @@ class FTE(Generic[Plaintext, Covertext]):
             self._max_frame_bytes = effective + 1 + self._CIPHERTEXT_EXPANSION
             return
 
-        # AE over a finite non-bytes input: the plaintext is the shortlex
-        # serialization of an input rank in [0, n_in), so the largest frame is
-        # fixed by the serialization of n_in - 1. There is no separate resource
-        # knob (max_plaintext_bytes was rejected earlier).
-        max_pt_bytes = frame.rank_byte_length(self._n_in - 1)
+        # AE over a finite non-bytes input: the plaintext is the fixed-width
+        # big-endian serialization of an input rank in [0, n_in), padded to the
+        # smallest W with 256**W >= n_in, so every frame has the same length
+        # and the covertext reveals nothing about the rank. (The shortlex
+        # length of n_in - 1 would be one byte short for e.g. n_in = 257.)
+        # There is no separate resource knob (max_plaintext_bytes was rejected
+        # earlier).
+        if self._n_in is None:
+            raise FormatCapacityError(
+                "a non-bytes input_format must expose a finite cardinality "
+                "for the 'aes-ctr-hmac' cipher"
+            )
+        max_pt_bytes = ((self._n_in - 1).bit_length() + 7) // 8
         self._resource_max = max_pt_bytes
         self._capacity_limit = max_pt_bytes
         self._max_plaintext_bytes = max_pt_bytes
@@ -499,8 +512,9 @@ class FTE(Generic[Plaintext, Covertext]):
         back to a 1 MiB default, and an explicit ``max_plaintext_bytes``
         lowers it further. It is also the guard that lets ``decrypt`` reject
         an oversized covertext before materializing a huge integer. For a
-        finite non-bytes input it is the fixed serialization size of the
-        input's largest rank; for the deterministic cipher it is ``None``.
+        finite non-bytes input it is the fixed serialization width of every
+        input rank, set by the input's cardinality (so the frame length never
+        depends on the plaintext); for the deterministic cipher it is ``None``.
         """
 
         return self._max_plaintext_bytes
@@ -654,7 +668,7 @@ class FTE(Generic[Plaintext, Covertext]):
                 raise InvalidPlaintextError(
                     "plaintext rank is outside the input format's rank space"
                 )
-            pt_bytes = frame.rank_to_bytes(r)
+            pt_bytes = r.to_bytes(self._max_plaintext_bytes, "big")
 
         ciphertext = self._encrypter.encrypt(pt_bytes)
         framed = self._FRAME_VERSION + ciphertext
@@ -667,6 +681,14 @@ class FTE(Generic[Plaintext, Covertext]):
             ) from exc
 
     def _decrypt_ae(self, covertext: Covertext) -> Plaintext:
+        # A bytes covertext longer than the largest frame can never decrypt;
+        # reject it before rank() materializes a huge integer from junk.
+        if (
+            isinstance(self._output_format, BytesFormat)
+            and isinstance(covertext, (bytes, bytearray))
+            and len(covertext) > self._max_frame_bytes
+        ):
+            raise InvalidCovertextError("invalid covertext")
         try:
             index = self._output_format.rank(covertext)
         except Exception as exc:
@@ -704,7 +726,9 @@ class FTE(Generic[Plaintext, Covertext]):
 
         if self._input_is_bytes:
             return pt_bytes
-        r = frame.bytes_to_rank(pt_bytes)
+        if len(pt_bytes) != self._max_plaintext_bytes:
+            raise InvalidCovertextError("invalid covertext")
+        r = int.from_bytes(pt_bytes, "big")
         if r >= self._n_in:
             raise InvalidCovertextError("invalid covertext")
         return self._input_format.unrank(r)

--- a/tests/data/v1_wire_vectors.json
+++ b/tests/data/v1_wire_vectors.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Frozen wire vectors for the current AE format (AES-CTR + HMAC-SHA256). Each covertext was produced by fte.FTE(output_format=..., key=...) and must keep decrypting to the same plaintext, byte for byte.",
+  "comment": "Frozen wire vectors for the current AE format (AES-CTR + HMAC-SHA256). Each covertext was produced by fte.FTE(output_format=..., key=...) and must keep decrypting to the same plaintext, byte for byte. A vector carrying input_pattern/input_length_kw uses a non-bytes input_format with cipher='aes-ctr-hmac' (the input rank is serialized at a fixed width set by the input cardinality); the non-bytes-input vector was frozen at 0.4.0.",
   "vectors": [
     {
       "pattern": "^[0-9a-f]+$",
@@ -29,6 +29,19 @@
       "key_hex": "2f5052c9fd15b19a18c584d01363568198613f0c34e84409ef7938709a159ec2",
       "plaintext_hex": "68656c6c6f20776f726c64",
       "covertext_hex": "474554202f2f77726e633936706974626176676f6430707a30376f6d6a6b3977677a7079676565663862642f6167623632352f6435776e3073756e386a7a37326b7520485454502f312e31"
+    },
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "length": 12
+      },
+      "pattern": "^[0-9a-f]+$",
+      "length_kw": {
+        "length": 256
+      },
+      "key_hex": "3b8f2d6c0a4e9d17f5c2a8e6b1d4790c5e3a1f8d2b6c4e0a7f9d1c3b5a8e6d2f",
+      "plaintext_hex": "333134313539323635333538",
+      "covertext_hex": "30303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032376264653233666433616135393333386633363565383636393064653361343364336433663662303238343835336434393765313334643864666163393964613462"
     }
   ]
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -320,6 +320,21 @@ class Tests(unittest.TestCase):
         for plaintext in (b"", b"x", b"hello", os.urandom(64)):
             self.assertEqual(receiver.decrypt(sender.encrypt(plaintext)), plaintext)
 
+    def test_bytes_output_rejects_oversized_covertext_cheaply(self):
+        cipher = fte.FTE(output_format=fte.BytesFormat(), key=bytes(32))
+
+        junk = b"\x00" * (cipher.max_plaintext_bytes + 1000)
+        with self.assertRaises(fte.InvalidCovertextError):
+            cipher.decrypt(junk)
+        # The size guard accepts a bytearray covertext as well.
+        with self.assertRaises(fte.InvalidCovertextError):
+            cipher.decrypt(bytearray(junk))
+        # Non-bytes covertexts still fail through the format's rank().
+        with self.assertRaises(fte.InvalidCovertextError):
+            cipher.decrypt("not bytes")
+        for plaintext in (b"", b"hello", os.urandom(64)):
+            self.assertEqual(cipher.decrypt(cipher.encrypt(plaintext)), plaintext)
+
     def test_max_plaintext_bytes_zero_allows_only_empty(self):
         cipher = fte.FTE(output_format=HexFormat(), key=KEY, max_plaintext_bytes=0)
 

--- a/tests/test_engine_matrix.py
+++ b/tests/test_engine_matrix.py
@@ -18,6 +18,7 @@ import math
 import unittest
 
 import fte
+from fte import frame
 from fte.core import (
     FTE,
     FormatCapacityError,
@@ -181,6 +182,23 @@ class NoSliceDigitsFormat:
         if type(index) is not int or not 0 <= index < self.cardinality:
             raise ValueError(f"index {index!r} out of range")
         return str(index).zfill(self._length)
+
+
+class CountFormat:
+    """The integers ``range(n)`` as their own ranks: a minimal finite format."""
+
+    def __init__(self, n):
+        self.cardinality = n
+
+    def rank(self, value, /):
+        if type(value) is not int or not 0 <= value < self.cardinality:
+            raise ValueError(f"{value!r} is not a member of this format")
+        return value
+
+    def unrank(self, index, /):
+        if type(index) is not int or not 0 <= index < self.cardinality:
+            raise ValueError(f"index {index!r} out of range")
+        return index
 
 
 # A deterministic spread of distinct ranks to sample from a large domain.
@@ -375,6 +393,99 @@ class Tests(unittest.TestCase):
             FTE(input_format=digits, output_format=tiny,
                 cipher="aes-ctr-hmac", key=KEY_AE)
 
+    def test_ae_non_bytes_requires_finite_input(self):
+        # A non-bytes input with no cardinality has no fixed rank width, so
+        # the AE path refuses it up front instead of failing mid-arithmetic.
+        class UnboundedDigits:
+            def rank(self, value, /):
+                return int(value)
+
+            def unrank(self, index, /):
+                return str(index)
+
+        with self.assertRaises(FormatCapacityError) as caught:
+            FTE(input_format=UnboundedDigits(), output_format=BIG_HEX,
+                cipher="aes-ctr-hmac", key=KEY_AE)
+        self.assertIn("finite cardinality", str(caught.exception))
+
+    def test_ae_non_bytes_covertext_length_is_plaintext_independent(self):
+        # The rank is serialized at a fixed width, so a variable-length output
+        # gets the same frame length for the smallest, a middle, and the
+        # largest input value: the covertext length reveals nothing about it.
+        digits = fte.RegexFormat(r"^[0-9]+$", length=12)
+        var_hex = fte.RegexFormat(r"^[0-9a-f]+$", min_length=1, max_length=400)
+        eng = FTE(input_format=digits, output_format=var_hex,
+                  cipher="aes-ctr-hmac", key=KEY_AE)
+        lengths = set()
+        for pt in (b"000000000000", b"000000065536", b"999999999999"):
+            for _ in range(8):
+                ct = eng.encrypt(pt)
+                lengths.add(len(ct))
+                self.assertEqual(eng.decrypt(ct), pt)
+        self.assertEqual(len(lengths), 1, lengths)
+
+    def test_ae_non_bytes_rejects_wrong_width_plaintext(self):
+        # An authentic frame whose plaintext is not exactly the fixed width
+        # was never produced by encrypt(): shorter (a shortlex-style encoding)
+        # and longer (padded) serializations are both rejected.
+        digits = fte.RegexFormat(r"^[0-9]+$", length=6)
+        eng = FTE(input_format=digits, output_format=BIG_HEX,
+                  cipher="aes-ctr-hmac", key=KEY_AE)
+        width = eng.max_plaintext_bytes
+        self.assertEqual(width, 3)  # 10**6 - 1 needs 20 bits
+        for pt_bytes in (b"\x00" * (width - 1), b"\x00" * (width + 1)):
+            framed = frame.FRAME_VERSION + eng._encrypter.encrypt(pt_bytes)
+            forged = BIG_HEX.unrank(frame.bytes_to_rank(framed))
+            with self.assertRaises(InvalidCovertextError):
+                eng.decrypt(forged)
+        # The genuine width still round-trips (rank 0 is all-zero bytes).
+        framed = frame.FRAME_VERSION + eng._encrypter.encrypt(b"\x00" * width)
+        self.assertEqual(
+            eng.decrypt(BIG_HEX.unrank(frame.bytes_to_rank(framed))), b"000000"
+        )
+
+    def test_ae_non_bytes_rejects_empty_plaintext_frame(self):
+        # An authentic frame carrying a 0-byte plaintext is rejected when the
+        # fixed width is positive: it is not a shortlex spelling of rank 0.
+        digits = fte.RegexFormat(r"^[0-9]+$", length=6)
+        eng = FTE(input_format=digits, output_format=BIG_HEX,
+                  cipher="aes-ctr-hmac", key=KEY_AE)
+        self.assertGreater(eng.max_plaintext_bytes, 0)
+        framed = frame.FRAME_VERSION + eng._encrypter.encrypt(b"")
+        forged = BIG_HEX.unrank(frame.bytes_to_rank(framed))
+        with self.assertRaises(InvalidCovertextError):
+            eng.decrypt(forged)
+
+    def test_ae_non_bytes_zero_width_rejects_one_byte_frame(self):
+        # A cardinality-1 input serializes its only rank at width 0, so the
+        # empty plaintext is the sole authentic frame; a 1-byte frame (rank 0
+        # written at width 1) was never produced by encrypt().
+        one_word = fte.RegexFormat(r"^a+$", length=5)
+        eng = FTE(input_format=one_word, output_format=BIG_HEX,
+                  cipher="aes-ctr-hmac", key=KEY_AE)
+        self.assertEqual(eng.max_plaintext_bytes, 0)
+        framed = frame.FRAME_VERSION + eng._encrypter.encrypt(b"\x00")
+        forged = BIG_HEX.unrank(frame.bytes_to_rank(framed))
+        with self.assertRaises(InvalidCovertextError):
+            eng.decrypt(forged)
+        # The genuine empty frame still decrypts to the one word.
+        framed = frame.FRAME_VERSION + eng._encrypter.encrypt(b"")
+        self.assertEqual(
+            eng.decrypt(BIG_HEX.unrank(frame.bytes_to_rank(framed))), b"aaaaa"
+        )
+
+    def test_ae_non_bytes_width_is_fixed_by_input_cardinality(self):
+        # W is the smallest width with 256**W >= n_in (W == 0 for n_in == 1),
+        # not the shortlex length of n_in - 1 (which is 1 for n_in == 257).
+        expected = {1: 0, 2: 1, 255: 1, 256: 1, 257: 2, 65536: 2, 65537: 3}
+        for n, width in expected.items():
+            with self.subTest(n=n):
+                eng = FTE(input_format=CountFormat(n), output_format=BIG_HEX,
+                          cipher="aes-ctr-hmac", key=KEY_AE)
+                self.assertEqual(eng.max_plaintext_bytes, width)
+                for value in {0, n // 2, n - 1}:
+                    self.assertEqual(eng.decrypt(eng.encrypt(value)), value)
+
     # ---- ValueError / error matrix for bad configs --------------------- #
     def test_tweak_with_ae_is_rejected(self):
         eng = FTE(output_format=BIG_HEX, key=KEY_AE)
@@ -430,6 +541,18 @@ class Tests(unittest.TestCase):
         fmt = DigitsFormat(6, fingerprint=b"fp:d6")  # 1e6, on the floor
         eng = FTE(input_format=fmt, output_format=fmt,
                   cipher=ToyCipher(), key=KEY_UNUSED)
+        self.assertEqual(eng.decrypt(eng.encrypt("000042")), "000042")
+
+    def test_small_domain_cross_format_is_judged_on_the_input(self):
+        # A deterministic map's strength is bounded by the input space, so the
+        # floor applies to n_in even when the output clears it.
+        fout = DigitsFormat(7, fingerprint=b"fp:out7")  # 1e7, above the floor
+        with self.assertRaises(SmallDomainError) as caught:
+            FTE(input_format=DigitsFormat(5, fingerprint=b"fp:in5"),
+                output_format=fout, cipher=ToyCipher(), key=KEY_UNUSED)
+        self.assertIn("input domain", str(caught.exception))
+        eng = FTE(input_format=DigitsFormat(6, fingerprint=b"fp:in6"),
+                  output_format=fout, cipher=ToyCipher(), key=KEY_UNUSED)
         self.assertEqual(eng.decrypt(eng.encrypt("000042")), "000042")
 
     def test_small_domain_slice_names_offending_lengths(self):

--- a/tests/test_ff1_integration.py
+++ b/tests/test_ff1_integration.py
@@ -56,13 +56,15 @@ class Tests(unittest.TestCase):
     def test_wrong_tweak_rejected_when_output_dwarfs_input(self):
         # N_out / N_in > 2**60, so a wrong-tweak decryption almost surely
         # deciphers to a rank >= N_in and is rejected as never-a-covertext.
-        digits = fte.RegexFormat(r"^[0-9]+$", length=4)      # 10**4
-        hex_fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=20)  # 16**20 = 2**80
+        # The input domain must clear the one-million floor, so 10**6
+        # digits map into 16**24 = 2**96 hex words.
+        digits = fte.RegexFormat(r"^[0-9]+$", length=6)      # 10**6
+        hex_fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=24)  # 16**24 = 2**96
         self.assertGreater(hex_fmt.cardinality / digits.cardinality, 2 ** 60)
         eng = FTE(input_format=digits, output_format=hex_fmt, cipher="ff1",
                   key=KEY)
-        ct = eng.encrypt(b"1234", tweak=b"per-record-A")
-        self.assertEqual(eng.decrypt(ct, tweak=b"per-record-A"), b"1234")
+        ct = eng.encrypt(b"123456", tweak=b"per-record-A")
+        self.assertEqual(eng.decrypt(ct, tweak=b"per-record-A"), b"123456")
         with self.assertRaises(InvalidCovertextError):
             eng.decrypt(ct, tweak=b"per-record-B")
 

--- a/tests/test_wire_compat.py
+++ b/tests/test_wire_compat.py
@@ -2,7 +2,9 @@
 
 Every vector in ``tests/data/v1_wire_vectors.json`` was produced by the current
 libfte through ``FTE(output_format=..., key=...)`` and must decrypt to the exact
-same plaintext, byte for byte, so any wire-format regression fails here.
+same plaintext, byte for byte, so any wire-format regression fails here. A
+vector carrying ``input_pattern`` uses a non-bytes ``input_format`` with the
+``aes-ctr-hmac`` cipher (fixed-width rank serialization, frozen at 0.4.0).
 """
 
 import json
@@ -25,6 +27,22 @@ def _load_vectors():
         return json.load(handle)["vectors"]
 
 
+def _build_cipher(vector):
+    fmt = fte.RegexFormat(vector["pattern"], **vector["length_kw"])
+    key = bytes.fromhex(vector["key_hex"])
+    if "input_pattern" not in vector:
+        return fte.FTE(output_format=fmt, key=key)
+    input_fmt = fte.RegexFormat(
+        vector["input_pattern"], **vector["input_length_kw"]
+    )
+    return fte.FTE(
+        input_format=input_fmt,
+        output_format=fmt,
+        key=key,
+        cipher="aes-ctr-hmac",
+    )
+
+
 class Tests(unittest.TestCase):
     def test_vectors_file_present_and_nonempty(self):
         self.assertTrue(VECTORS_PATH.exists(), VECTORS_PATH)
@@ -33,13 +51,14 @@ class Tests(unittest.TestCase):
     def test_every_v1_vector_decrypts_identically(self):
         for i, vector in enumerate(_load_vectors()):
             with self.subTest(vector=i, pattern=vector["pattern"]):
-                fmt = fte.RegexFormat(vector["pattern"], **vector["length_kw"])
-                cipher = fte.FTE(
-                    output_format=fmt, key=bytes.fromhex(vector["key_hex"])
-                )
+                cipher = _build_cipher(vector)
                 covertext = bytes.fromhex(vector["covertext_hex"])
                 expected = bytes.fromhex(vector["plaintext_hex"])
                 self.assertEqual(cipher.decrypt(covertext), expected)
+
+    def test_non_bytes_input_vector_is_present(self):
+        # The 0.4.0 fixed-width rank serialization is itself a wire contract.
+        self.assertTrue(any("input_pattern" in v for v in _load_vectors()))
 
     def test_wrong_key_rejects_a_frozen_vector(self):
         vector = _load_vectors()[0]


### PR DESCRIPTION
Re-lands #96 on `master`. #96 was merged while its base was still the `docs/accuracy-0.4.0` branch (that branch was not deleted after #93 merged, so GitHub did not retarget), so its changes landed on the docs branch instead of `master`. This PR cherry-picks that squash commit onto `master` unchanged; review already happened in #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)