### PR TITLE
Make libffx a hard dependency and freeze the ff1 wire contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,fpe]"
+          pip install -e ".[dev]"
 
       - name: Run tests
         run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,12 +1,13 @@
 # libfte Build Instructions
 
 libfte itself is pure Python; there is nothing in this repository to compile.
-It depends on two packages:
+It depends on three packages:
 
 - `cryptography` (AES-CTR): a compiled extension that bundles OpenSSL. PyPI
   ships prebuilt wheels for supported platforms, so no compiler is normally
   needed.
 - `regex2dfa` (pattern compilation): pure Python.
+- `libffx` (the `ff1` format-preserving cipher): pure Python.
 
 ## Requirements
 
@@ -26,14 +27,6 @@ For development (tests and coverage):
 ```bash
 pip install -e ".[dev]"
 ```
-
-The optional `fpe` extra adds `libffx>=2.0.0`, which provides `cipher="ff1"`:
-
-```bash
-pip install -e ".[dev,fpe]"
-```
-
-Without it, `tests/test_ff1_integration.py` and examples 10 and 11 skip.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ That gives a 2x2 of behaviors:
 | **`aes-ctr-hmac`** (randomized, authenticated, expanding) | authenticated encryption over bytes | **classic FTE**: bytes hidden as a chosen covertext format |
 
 `cipher="ff1"` is the built-in format-preserving cipher (NIST SP 800-38G FF1,
-via the optional [libffx](https://github.com/kpdyer/libffx) extra:
-`pip install 'fte[fpe]'`). The deterministic column also takes any object with
-`encrypt_int(x, *, domain, tweak)` / `decrypt_int(y, *, domain, tweak)` forming
-a permutation of `range(domain)`, so you can supply your own cipher.
+via [libffx](https://github.com/kpdyer/libffx)). The deterministic column also
+takes any object with `encrypt_int(x, *, domain, tweak)` /
+`decrypt_int(y, *, domain, tweak)` forming a permutation of `range(domain)`, so
+you can supply your own cipher.
 
 **FPE is the equal-formats case**: pass the same format as `input_format` and
 `output_format` and the deterministic cipher is inferred.
@@ -88,7 +88,7 @@ covertext can begin with a short run of the format's lowest-ranked symbols
 
 For **format-preserving encryption**, use the same format on both sides. Equal
 formats infer the deterministic `ff1` cipher, and length is preserved
-automatically (needs `pip install 'fte[fpe]'`):
+automatically:
 
 ```python
 digits = fte.RegexFormat(r'^[0-9]+$', length=9)   # a 9-digit language
@@ -213,8 +213,8 @@ The `cipher` is `"aes-ctr-hmac"`, `"ff1"`, a deterministic cipher **object**
 (any object with `encrypt_int` / `decrypt_int`), or `None` to infer it: a bytes
 input picks `"aes-ctr-hmac"`; two formats with equal fingerprints pick `"ff1"`;
 any other pair must name the cipher. `"aes-ctr-hmac"` needs a 32-byte key (16
-encryption + 16 MAC); `"ff1"` needs 16/24/32 and requires the extra
-(`pip install 'fte[fpe]'`); a cipher object carries its own key.
+encryption + 16 MAC); `"ff1"` needs 16/24/32; a cipher object carries its own
+key.
 
 A deterministic cipher infers **length preservation** from the formats: when
 input and output are the same format and it can name its per-length slices, a

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -26,10 +26,10 @@ pip install fte
 ```
 
 libfte itself is pure Python. It depends on `cryptography` (AES-CTR on
-OpenSSL; it ships prebuilt wheels with OpenSSL bundled) and `regex2dfa` (pure
-Python), so no compiler or system library is needed on the platforms
-`cryptography` publishes wheels for. Format-preserving encryption needs the
-optional extra: `pip install 'fte[fpe]'`.
+OpenSSL; it ships prebuilt wheels with OpenSSL bundled), `regex2dfa` (pure
+Python) and `libffx` (pure Python; the FF1 format-preserving cipher), so no
+compiler or system library is needed on the platforms `cryptography` publishes
+wheels for.
 
 ## Quick Example
 
@@ -64,8 +64,8 @@ covertext can begin with a short run of the format's lowest-ranked symbols
 covertext; a fixed `length` is the special case where they are equal.
 
 **Format-preserving and deterministic FTE.** `cipher="ff1"` (NIST SP 800-38G
-FF1 via [libffx](https://github.com/kpdyer/libffx); `pip install 'fte[fpe]'`)
-is deterministic and zero-expansion: pass the same format as `input_format`
+FF1 via [libffx](https://github.com/kpdyer/libffx)) is deterministic and
+zero-expansion: pass the same format as `input_format`
 and `output_format` to re-encrypt a value in place (FPE, length preserved), or
 two different formats for a deterministic rank map between them. It refuses an
 input domain below one million values, is unauthenticated, and leaks plaintext

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -183,9 +183,8 @@ floor or construction raises `SmallDomainError`; with inferred length
 preservation every non-empty length slice must clear it. The floor applies to
 the input domain because the strength of a deterministic map is bounded by the
 input space, not by the key. Passing the same fingerprinted format on both
-sides infers `cipher="ff1"`. The cardinality check runs before libffx is
-imported, so a bare provider such as `LowerHex` is refused even without the
-`fpe` extra:
+sides infers `cipher="ff1"`. A bare provider such as `LowerHex`, which exposes
+no cardinality, is refused at construction:
 
 ```python
 import fte

--- a/examples/09_authenticated_fte.py
+++ b/examples/09_authenticated_fte.py
@@ -9,12 +9,12 @@ on decrypt. That safety costs a fixed 29-byte frame: a version byte, a 12-byte
 random nonce, and a 16-byte HMAC-SHA256 tag (Encrypt-then-MAC over AES-128-CTR).
 
 Here the input is a structured (non-bytes) format -- a 12-digit decimal string --
-re-encrypted as hex. This uses only the built-in engine, no extra dependency.
+re-encrypted as hex.
 
 Because ``aes-ctr-hmac`` expands by that fixed overhead, the output format must
 have more capacity than the input; you cannot round-trip ``aes-ctr-hmac`` in
 place through one finite format (that is the job of a deterministic cipher, such
-as the ``ff1`` format-preserving cipher from the optional libffx integration).
+as the ``ff1`` format-preserving cipher).
 """
 
 import os

--- a/examples/10_fpe_digits.py
+++ b/examples/10_fpe_digits.py
@@ -10,10 +10,6 @@ fixed-width field (an account number, a customer id, a batch of tickets).
 The transform is deterministic and unauthenticated: equal plaintexts map to
 equal covertexts, so pass a distinct per-record ``tweak`` (a column name, a row
 id) to keep encryptions of the same value in different contexts independent.
-
-Requires the optional libffx extra::
-
-    pip install fte[fpe]
 """
 
 import os
@@ -29,14 +25,8 @@ def main():
     id_format = fte.RegexFormat(r"^[0-9]+$", length=9)
     key = os.urandom(16)  # FF1 keys are 16/24/32 bytes; NOT an AES-CTR-HMAC key.
 
-    try:
-        # Same format in and out -> FPE. Length is preserved automatically.
-        cipher = fte.FTE(input_format=id_format, output_format=id_format,
-                         key=key)
-    except ImportError as exc:
-        print(exc)
-        print("\nSkipping: install the libffx extra to run this example.")
-        return
+    # Same format in and out -> FPE. Length is preserved automatically.
+    cipher = fte.FTE(input_format=id_format, output_format=id_format, key=key)
 
     # Synthetic demo identifiers (not real records).
     for account in (b"100000042", b"100000043", b"100000042"):

--- a/examples/11_deterministic_fte.py
+++ b/examples/11_deterministic_fte.py
@@ -12,10 +12,6 @@ Because the output space (16**16) is far larger than the input space (10**12),
 most hex strings are not the image of any 12-digit input; decrypting one raises
 InvalidCovertextError. And because it is deterministic, use a per-record
 ``tweak`` to separate encryptions of the same value.
-
-Requires the optional libffx extra::
-
-    pip install fte[fpe]
 """
 
 import os
@@ -31,17 +27,12 @@ def main():
     hex_out = fte.RegexFormat(r"^[0-9a-f]+$", length=16)  # 16**16 words
     key = os.urandom(16)  # FF1 key (16/24/32 bytes), never reused for AE.
 
-    try:
-        cipher = fte.FTE(
-            input_format=digits,
-            output_format=hex_out,
-            cipher="ff1",
-            key=key,
-        )
-    except ImportError as exc:
-        print(exc)
-        print("\nSkipping: install the libffx extra to run this example.")
-        return
+    cipher = fte.FTE(
+        input_format=digits,
+        output_format=hex_out,
+        cipher="ff1",
+        key=key,
+    )
 
     for plaintext in (b"000000000001", b"123456789012"):
         covertext = cipher.encrypt(plaintext, tweak=b"batch-2026")

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,6 @@ This directory contains examples demonstrating various features of the libfte li
 
 ```bash
 pip install fte
-pip install 'fte[fpe]'   # examples 10 and 11: the ff1 cipher needs libffx
 ```
 
 ## Examples
@@ -22,8 +21,8 @@ pip install 'fte[fpe]'   # examples 10 and 11: the ff1 cipher needs libffx
 | `07_multiple_messages.py` | Parsing a stream of fixed-length covertexts |
 | `08_custom_format.py` | Writing your own `RankedFormat` provider |
 | `09_authenticated_fte.py` | Authenticated FTE (`aes-ctr-hmac`) over a non-bytes input format |
-| `10_fpe_digits.py` | FPE: equal formats re-encrypt a value in place (needs `fte[fpe]`) |
-| `11_deterministic_fte.py` | Deterministic cross-format FTE: digits to hex tokens (needs `fte[fpe]`) |
+| `10_fpe_digits.py` | FPE: equal formats re-encrypt a value in place |
+| `11_deterministic_fte.py` | Deterministic cross-format FTE: digits to hex tokens |
 
 ## Running Examples
 

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -9,7 +9,7 @@ format. Two independent choices shape it:
 * the **format pair** (``input_format`` / ``output_format``), and
 * the **cipher**: ``"aes-ctr-hmac"`` (randomized, authenticated, expanding:
   the classic AES-CTR + HMAC path) or ``"ff1"`` (deterministic, zero-expansion,
-  format-preserving, via the optional libffx package).
+  format-preserving, via the libffx package).
 
 FPE is simply the case ``input_format == output_format``: equal formats infer
 the deterministic cipher and re-encrypt a value in place. Classic FTE (bytes
@@ -23,12 +23,13 @@ hidden as covertext) is the case where the input is raw bytes::
     >>> covertext = cipher.encrypt(b'secret message')
     >>> assert cipher.decrypt(covertext) == b'secret message'
 
-    >>> digits = fte.RegexFormat('^[0-9]+$', length=9)  # doctest: +SKIP
-    >>> ssn = fte.FTE(                                  # doctest: +SKIP
+    >>> digits = fte.RegexFormat('^[0-9]+$', length=9)
+    >>> ssn = fte.FTE(
     ...     input_format=digits,
     ...     output_format=digits,                       # equal formats -> FPE
     ...     key=bytes(range(16)),
-    ... )                                               # needs the libffx extra
+    ... )
+    >>> assert ssn.decrypt(ssn.encrypt(b'123456789')) == b'123456789'
 
 ``fte.RegexFormat`` is the built-in regex provider and ``fte.BytesFormat`` is
 the raw-bytes identity format (the default input). Supply your own

--- a/fte/core.py
+++ b/fte/core.py
@@ -92,17 +92,10 @@ _DETERMINISTIC_TWEAK_PREFIX = b"fte:v2:ff1:1|"
 
 
 def _load_ff1():
-    """Import ``ffx.FF1`` lazily, with a directive error when it is missing."""
+    """Import ``ffx.FF1`` lazily so ``import fte`` does not pay for libffx."""
 
-    try:
-        from ffx import FF1
-    except ImportError as exc:  # pragma: no cover - depends on optional dep
-        raise ImportError(
-            "cipher='ff1' requires the libffx package providing ffx.FF1, "
-            "which is not importable. Install it with `pip install "
-            "libffx>=2.0.0`, or install this package with its extra: "
-            "`pip install fte[fpe]`."
-        ) from exc
+    from ffx import FF1
+
     return FF1
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ classifiers = [
 dependencies = [
     "cryptography>=41.0",
     "regex2dfa>=0.2.0",
+    # The built-in cipher="ff1" (format-preserving, deterministic,
+    # zero-expansion) is libffx's FF1; pure Python.
+    "libffx>=2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -42,8 +45,6 @@ dev = [
     "pytest>=7.0",
     "pytest-cov",
 ]
-# Format-preserving (deterministic, zero-expansion) transforms via libffx.
-fpe = ["libffx>=2.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/kpdyer/libfte"

--- a/tests/data/ff1_wire_vectors.json
+++ b/tests/data/ff1_wire_vectors.json
@@ -1,0 +1,123 @@
+{
+  "comment": "Frozen wire vectors for the deterministic (cipher='ff1') path: rank -> libffx FF1 -> unrank, with the tweak derived from the 'fte:v2:ff1:1|' namespace, both format fingerprints, the length mode, and (when length is preserved) the value's length. Each covertext was produced by fte.FTE(input_format=..., output_format=..., cipher=..., key=...).encrypt(plaintext, tweak=...) and, because the path is deterministic, must keep being produced and decrypted byte for byte. cipher null means inferred from equal formats.",
+  "vectors": [
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "length": 16
+      },
+      "output_pattern": "^[0-9]+$",
+      "output_length_kw": {
+        "length": 16
+      },
+      "cipher": null,
+      "preserve_length": true,
+      "key_hex": "000102030405060708090a0b0c0d0e0f",
+      "tweak_hex": "",
+      "plaintext_hex": "34313131313131313131313131313131",
+      "covertext_hex": "32393235343130313635363139363435"
+    },
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "length": 16
+      },
+      "output_pattern": "^[0-9]+$",
+      "output_length_kw": {
+        "length": 16
+      },
+      "cipher": null,
+      "preserve_length": true,
+      "key_hex": "000102030405060708090a0b0c0d0e0f",
+      "tweak_hex": "6163636f756e74732e6e756d626572",
+      "plaintext_hex": "30313233343536373839303132333435",
+      "covertext_hex": "35313538323036383838343234363337"
+    },
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "min_length": 6,
+        "max_length": 9
+      },
+      "output_pattern": "^[0-9]+$",
+      "output_length_kw": {
+        "min_length": 6,
+        "max_length": 9
+      },
+      "cipher": null,
+      "preserve_length": true,
+      "key_hex": "000102030405060708090a0b0c0d0e0f1011121314151617",
+      "tweak_hex": "",
+      "plaintext_hex": "313233343536",
+      "covertext_hex": "303636303632"
+    },
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "min_length": 6,
+        "max_length": 9
+      },
+      "output_pattern": "^[0-9]+$",
+      "output_length_kw": {
+        "min_length": 6,
+        "max_length": 9
+      },
+      "cipher": null,
+      "preserve_length": true,
+      "key_hex": "000102030405060708090a0b0c0d0e0f1011121314151617",
+      "tweak_hex": "6f72646572732e6163636f756e74",
+      "plaintext_hex": "313233343536373839",
+      "covertext_hex": "373830373032353639"
+    },
+    {
+      "input_pattern": "^[a-z]+$",
+      "input_length_kw": {
+        "min_length": 5,
+        "max_length": 8
+      },
+      "output_pattern": "^[a-z]+$",
+      "output_length_kw": {
+        "min_length": 5,
+        "max_length": 8
+      },
+      "cipher": null,
+      "preserve_length": true,
+      "key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "tweak_hex": "636f6c3a656d61696c",
+      "plaintext_hex": "616c696365",
+      "covertext_hex": "71776d6362"
+    },
+    {
+      "input_pattern": "^[0-9]+$",
+      "input_length_kw": {
+        "length": 8
+      },
+      "output_pattern": "^[0-9a-f]+$",
+      "output_length_kw": {
+        "length": 16
+      },
+      "cipher": "ff1",
+      "preserve_length": false,
+      "key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "tweak_hex": "62617463682d32303236",
+      "plaintext_hex": "3031323334353637",
+      "covertext_hex": "38646232313435313032353866396230"
+    },
+    {
+      "input_pattern": "^[a-z]+$",
+      "input_length_kw": {
+        "length": 8
+      },
+      "output_pattern": "^[A-Za-z0-9]+$",
+      "output_length_kw": {
+        "length": 8
+      },
+      "cipher": "ff1",
+      "preserve_length": false,
+      "key_hex": "000102030405060708090a0b0c0d0e0f",
+      "tweak_hex": "",
+      "plaintext_hex": "636f766572747874",
+      "covertext_hex": "3475526644693455"
+    }
+  ]
+}

--- a/tests/test_ff1_integration.py
+++ b/tests/test_ff1_integration.py
@@ -1,16 +1,11 @@
 """Integration tests for the real deterministic cipher (``cipher="ff1"``).
 
 These exercise :class:`fte.FTE` against the genuine format-preserving cipher
-from libffx (``pip install 'fte[fpe]'``, which CI installs). Without it the
-whole module skips via ``pytest.importorskip("ffx")``; the engine mechanics
-themselves are covered without ffx in ``test_engine_matrix.py``.
+from libffx, a hard dependency. The engine mechanics themselves are covered
+with a toy cipher object in ``test_engine_matrix.py``.
 """
 
 import unittest
-
-import pytest
-
-pytest.importorskip("ffx")
 
 import fte
 from fte.core import FTE, InvalidCovertextError

--- a/tests/test_ff1_wire_compat.py
+++ b/tests/test_ff1_wire_compat.py
@@ -1,0 +1,158 @@
+"""The deterministic (``cipher="ff1"``) wire contract is frozen.
+
+Two things pin it. First, every vector in ``tests/data/ff1_wire_vectors.json``
+was produced by the current libfte and, because the path is deterministic,
+must keep being *produced* as well as decrypted byte for byte. Second, the
+composition tests recompute a covertext by hand -- rank the plaintext, call
+libffx's ``FF1`` directly with the derived tweak, unrank the result -- so a
+change to the tweak derivation, the length-slice arithmetic, or the cipher in
+the loop fails here even if it still round-trips.
+
+The tweak derivation is spelled out literally rather than imported from
+:mod:`fte.core`, so that changing it there cannot silently pass.
+"""
+
+import hashlib
+import json
+import unittest
+from pathlib import Path
+
+from ffx import FF1
+
+import fte
+
+
+VECTORS_PATH = Path(__file__).resolve().parent / "data" / "ff1_wire_vectors.json"
+
+# The frozen namespace prefix; bumping it in fte.core is a wire-format change.
+TWEAK_PREFIX = b"fte:v2:ff1:1|"
+
+
+def _load_vectors():
+    with VECTORS_PATH.open() as handle:
+        return json.load(handle)["vectors"]
+
+
+def _engine(vector, key=None):
+    fin = fte.RegexFormat(vector["input_pattern"], **vector["input_length_kw"])
+    fout = fte.RegexFormat(
+        vector["output_pattern"], **vector["output_length_kw"]
+    )
+    return fte.FTE(
+        input_format=fin,
+        output_format=fout,
+        cipher=vector["cipher"],
+        key=bytes.fromhex(vector["key_hex"]) if key is None else key,
+    )
+
+
+def _tweak_base(fp_in, fp_out, mode_tag):
+    """The per-engine tweak: SHA-256 over the namespace and both fingerprints."""
+    return hashlib.sha256(
+        TWEAK_PREFIX
+        + len(fp_in).to_bytes(4, "big")
+        + fp_in
+        + len(fp_out).to_bytes(4, "big")
+        + fp_out
+        + mode_tag
+    ).digest()
+
+
+class FrozenVectors(unittest.TestCase):
+    def test_vectors_file_present_and_nonempty(self):
+        self.assertTrue(VECTORS_PATH.exists(), VECTORS_PATH)
+        self.assertGreater(len(_load_vectors()), 0)
+
+    def test_every_vector_is_reproduced_and_decrypted(self):
+        for i, vector in enumerate(_load_vectors()):
+            with self.subTest(
+                vector=i,
+                formats=(vector["input_pattern"], vector["output_pattern"]),
+            ):
+                eng = _engine(vector)
+                tweak = bytes.fromhex(vector["tweak_hex"])
+                plaintext = bytes.fromhex(vector["plaintext_hex"])
+                covertext = bytes.fromhex(vector["covertext_hex"])
+                self.assertEqual(eng.preserve_length, vector["preserve_length"])
+                self.assertEqual(eng.encrypt(plaintext, tweak=tweak), covertext)
+                self.assertEqual(eng.decrypt(covertext, tweak=tweak), plaintext)
+
+    def test_vectors_cover_both_length_modes(self):
+        modes = {v["preserve_length"] for v in _load_vectors()}
+        self.assertEqual(modes, {True, False})
+
+    def test_wrong_key_does_not_reproduce_a_frozen_vector(self):
+        vector = _load_vectors()[0]
+        key = bytes.fromhex(vector["key_hex"])
+        wrong = bytes(b ^ 0xFF for b in key)
+        eng = _engine(vector, key=wrong)
+        tweak = bytes.fromhex(vector["tweak_hex"])
+        plaintext = bytes.fromhex(vector["plaintext_hex"])
+        self.assertNotEqual(
+            eng.encrypt(plaintext, tweak=tweak),
+            bytes.fromhex(vector["covertext_hex"]),
+        )
+
+
+class Composition(unittest.TestCase):
+    """fte's covertext is exactly libffx FF1 applied to the rank."""
+
+    KEY = bytes(range(16))
+
+    def test_global_path_is_ff1_over_the_whole_rank_space(self):
+        digits = fte.RegexFormat(r"^[0-9]+$", length=8)
+        hex_fmt = fte.RegexFormat(r"^[0-9a-f]+$", length=16)
+        eng = fte.FTE(
+            input_format=digits, output_format=hex_fmt, cipher="ff1",
+            key=self.KEY,
+        )
+        self.assertFalse(eng.preserve_length)
+        tweak = b"batch-2026"
+        plaintext = b"01234567"
+
+        call_tweak = (
+            _tweak_base(digits.fingerprint, hex_fmt.fingerprint, b"G") + tweak
+        )
+        c = FF1(self.KEY).encrypt_int(
+            digits.rank(plaintext), domain=hex_fmt.cardinality, tweak=call_tweak
+        )
+        self.assertEqual(eng.encrypt(plaintext, tweak=tweak), hex_fmt.unrank(c))
+
+    def test_length_preserving_path_is_ff1_over_the_length_slice(self):
+        fmt = fte.RegexFormat(r"^[0-9]+$", min_length=6, max_length=9)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY)
+        self.assertTrue(eng.preserve_length)
+        tweak = b"orders.account"
+        plaintext = b"1234567"
+
+        offset, count = fmt.slice_bounds(len(plaintext))
+        call_tweak = (
+            _tweak_base(fmt.fingerprint, fmt.fingerprint, b"L")
+            + len(plaintext).to_bytes(4, "big")
+            + tweak
+        )
+        c = FF1(self.KEY).encrypt_int(
+            fmt.rank(plaintext) - offset, domain=count, tweak=call_tweak
+        )
+        self.assertEqual(eng.encrypt(plaintext, tweak=tweak), fmt.unrank(offset + c))
+
+    def test_default_tweak_is_the_empty_suffix(self):
+        # encrypt(pt) with no tweak is encrypt(pt, tweak=b""): the derived base
+        # is used bare, with nothing appended.
+        fmt = fte.RegexFormat(r"^[0-9]+$", length=16)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY)
+        plaintext = b"4111111111111111"
+        self.assertEqual(eng.encrypt(plaintext), eng.encrypt(plaintext, tweak=b""))
+        offset, count = fmt.slice_bounds(16)
+        call_tweak = (
+            _tweak_base(fmt.fingerprint, fmt.fingerprint, b"L")
+            + (16).to_bytes(4, "big")
+        )
+        c = FF1(self.KEY).encrypt_int(
+            fmt.rank(plaintext) - offset, domain=count, tweak=call_tweak
+        )
+        self.assertEqual(eng.encrypt(plaintext), fmt.unrank(offset + c))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **libffx is now a hard dependency** (`libffx>=2.0.0`) and the `fpe` extra is gone. `cipher="ff1"` is the built-in format-preserving cipher, and libffx is pure Python, MIT, and depends only on `cryptography`, which fte already requires. The extra never shipped in a release (0.3.0 has none), so there is no compatibility stub. CI installs `.[dev]` only.
- `tests/test_ff1_integration.py` no longer `importorskip`s `ffx`: a missing libffx now fails loudly instead of silently skipping. Examples 10 and 11 no longer catch `ImportError`, `_load_ff1` keeps its lazy import but drops the install-hint error, the FPE doctest in `fte/__init__.py` is un-skipped, and every doc mention of `fte[fpe]` is removed.
- **The ff1 wire contract is frozen.** The deterministic path only had round-trip tests, so the tweak derivation (`fte:v2:ff1:1|` namespace, both fingerprints, length mode, per-length suffix) could change without any failure while old covertexts became undecryptable. New `tests/data/ff1_wire_vectors.json` holds seven covertexts produced by the current engine (fixed-length and length-range FPE, digit and letter alphabets, cross-format FTE, 16/24/32-byte keys); since the path is deterministic each must be reproduced by `encrypt` as well as recovered by `decrypt`. `tests/test_ff1_wire_compat.py` additionally recomputes covertexts by hand through `ffx.FF1` with the derivation spelled out literally, so changing it in `fte.core` cannot pass silently.

Dependency bounds are otherwise unchanged: no exact pins and no cap on `cryptography`, whose major number bumps on every feature release.

## Test plan

- [x] Fresh venv, `pip install -e ".[dev]"` only: full suite passes (1357 tests, ff1 integration and wire-compat included), examples 10 and 11 run, `python -m doctest fte/__init__.py` passes.
- [x] Mutation check: bumping the tweak prefix in `fte/core.py` fails ten checks in `test_ff1_wire_compat.py`; reverting passes.
- [x] `grep` for `[fpe]`, `importorskip`, and "optional libffx" across the repo is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
