### PR TITLE
Trim accidental public surface before 0.4.0; fix the lazy-import test

### DIFF
--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -11,7 +11,7 @@ format. Two independent choices shape it:
   the classic AES-CTR + HMAC path) or ``"ff1"`` (deterministic, zero-expansion,
   format-preserving, via the libffx package).
 
-FPE is simply the case ``input_format == output_format``: equal formats infer
+FPE is simply the same format on both sides (equal fingerprints): equal formats infer
 the deterministic cipher and re-encrypt a value in place. Classic FTE (bytes
 hidden as covertext) is the case where the input is raw bytes::
 

--- a/fte/formats/bytes.py
+++ b/fte/formats/bytes.py
@@ -49,11 +49,5 @@ class BytesFormat:
             raise ValueError("index must be a non-negative integer")
         return frame.rank_to_bytes(index)
 
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, BytesFormat)
-
-    def __hash__(self) -> int:
-        return hash(BytesFormat)
-
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
         return "BytesFormat()"

--- a/fte/formats/regex/dfa.py
+++ b/fte/formats/regex/dfa.py
@@ -11,14 +11,10 @@ The algorithm is based on:
 """
 
 from itertools import groupby
-from typing import (
-    Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple, Union,
-)
+from typing import Dict, FrozenSet, List, NamedTuple, Optional, Set, Tuple
 
 __all__ = [
     "DFA",
-    "ParsedFst",
-    "parse_att_fst",
     "InvalidFSTFormat",
     "InvalidRankInput",
     "InvalidUnrankInput",
@@ -47,8 +43,11 @@ class InvalidUnrankInput(Exception):
     """Raised when a rank is outside the valid range."""
 
 
-class ParsedFst(NamedTuple):
+class _ParsedFst(NamedTuple):
     """A parsed automaton: the DFA structure without any ranking tables.
+
+    Internal to this module: :func:`_parse_att_fst` produces one and
+    :class:`DFA` consumes it.
 
     Attributes:
         start_state: The automaton's start state.
@@ -63,14 +62,14 @@ class ParsedFst(NamedTuple):
     symbols: Tuple[int, ...]
 
 
-def parse_att_fst(dfa_str: str) -> ParsedFst:
+def _parse_att_fst(dfa_str: str) -> _ParsedFst:
     """Parse a minimized AT&T FST formatted DFA string.
 
     Args:
         dfa_str: A minimized AT&T FST formatted DFA string.
 
     Returns:
-        The parsed automaton as a :class:`ParsedFst`.
+        The parsed automaton as a :class:`_ParsedFst`.
 
     Raises:
         InvalidFSTFormat: If the input has a line that is neither a transition
@@ -125,7 +124,7 @@ def parse_att_fst(dfa_str: str) -> ParsedFst:
     if states != list(range(len(states))):
         raise InvalidFSTFormat("DFA states must be numbered 0..N-1")
 
-    return ParsedFst(
+    return _ParsedFst(
         start_state=start_state,
         final_states=frozenset(final_states),
         transitions=tuple(transitions),
@@ -137,30 +136,26 @@ class DFA:
     """Rank and unrank the words of a regular language by length.
 
     Builds the Goldberg-Sipser counting table up to a maximum ``length`` from a
-    minimized AT&T FST string (parsed via :func:`parse_att_fst`) or from a
-    :class:`ParsedFst` supplied directly. :meth:`rank` and :meth:`unrank` then
-    map between a word and its lexicographic index among the accepted words of
+    minimized AT&T FST string. :meth:`rank` and :meth:`unrank` then map
+    between a word and its lexicographic index among the accepted words of
     that word's length, and :meth:`num_words` counts the accepted words of one
     length. Whether any words exist at the lengths the caller cares about is
     the caller's concern.
 
     Args:
-        dfa_str: A minimized AT&T FST formatted DFA string, or a
-            :class:`ParsedFst`.
+        dfa_str: A minimized AT&T FST formatted DFA string.
         length: The maximum word length the counting table supports.
 
     Raises:
-        InvalidFSTFormat: If the string does not parse (see
-            :func:`parse_att_fst`) or the alphabet has a symbol outside the
-            byte range 0..255.
+        InvalidFSTFormat: If the string does not parse (a line that is
+            neither a transition nor a final state, no states, no symbols,
+            or states not numbered densely from zero) or the alphabet has a
+            symbol outside the byte range 0..255.
     """
 
-    def __init__(self, dfa_str: Union[str, ParsedFst], length: int):
+    def __init__(self, dfa_str: str, length: int):
         self._length = length
-        if isinstance(dfa_str, ParsedFst):
-            parsed = dfa_str
-        else:
-            parsed = parse_att_fst(dfa_str)
+        parsed = _parse_att_fst(dfa_str)
         self._start_state = parsed.start_state
         self._num_states = 0
         self._symbols: List[int] = list(parsed.symbols)

--- a/tests/test_dfa.py
+++ b/tests/test_dfa.py
@@ -15,8 +15,6 @@ from fte.formats.regex.dfa import (
     InvalidFSTFormat,
     InvalidRankInput,
     InvalidUnrankInput,
-    ParsedFst,
-    parse_att_fst,
 )
 
 
@@ -78,19 +76,13 @@ class Tests(unittest.TestCase):
 
     def test_symbol_outside_byte_range_is_rejected(self):
         # The alphabet indexes a fixed 256-entry table: a symbol above 255
-        # cannot be stored and a negative one would alias another entry.
+        # cannot be stored and a negative one would alias another entry. The
+        # AT&T text itself parses (any integer is a symbol there); the DFA
+        # rejects it when it builds the table.
         for symbol in (256, 300, -1):
             with self.subTest(symbol=symbol):
                 with self.assertRaisesRegex(InvalidFSTFormat, "0..255"):
                     DFA(f"0\t1\t{symbol}\t{symbol}\n1\n", 2)
-                parsed = ParsedFst(
-                    start_state=0,
-                    final_states=frozenset({1}),
-                    transitions=((0, 1, symbol),),
-                    symbols=(symbol,),
-                )
-                with self.assertRaisesRegex(InvalidFSTFormat, "0..255"):
-                    DFA(parsed, 2)
         # The byte-range edges are fine.
         dfa = DFA("0\t1\t0\t0\n0\t1\t255\t255\n1\n", 1)
         self.assertEqual(dfa.unrank(0, 1), b"\x00")
@@ -110,55 +102,44 @@ class Tests(unittest.TestCase):
             DFA("0", 4)                # a final state but no transitions/symbols
         with self.assertRaises(InvalidFSTFormat):
             DFA("0\t1\t2", 4)          # a 3-field line is neither transition nor final
+        with self.assertRaises(InvalidFSTFormat):
+            DFA("0\t1", 4)             # nor is a 2-field line
+        with self.assertRaises(InvalidFSTFormat):
+            DFA("0\t2\t97\t97\n2", 4)  # states {0, 2} skip 1: not dense 0..N-1
 
-    def test_parse_att_fst_returns_structure(self):
-        # ``a[ab]*``: state 0 reads an 'a' to reach accepting state 1, which
-        # loops on 'a' and 'b'.
-        parsed = parse_att_fst(
+    def test_alphabet_is_sorted_and_deduplicated(self):
+        # ``[ab]+`` written with each 'b' transition listed before its 'a'
+        # transition and one 'a' transition repeated. The alphabet is the
+        # sorted set of symbols seen, so 'a' still ranks below 'b' and the
+        # duplicate line adds no symbol.
+        dfa = DFA(
+            "0\t1\t98\t98\n"
+            "0\t1\t97\t97\n"
             "0\t1\t97\t97\n"
             "1\t1\t98\t98\n"
             "1\t1\t97\t97\n"
-            "1\n"
+            "1\n",
+            2,
         )
-        self.assertIsInstance(parsed, ParsedFst)
-        self.assertEqual(parsed.start_state, 0)
-        self.assertEqual(parsed.final_states, frozenset({1}))
+        self.assertEqual(dfa.num_words(0), 0)   # start state 0 is not accepting
+        self.assertEqual(dfa.num_words(1), 2)
+        self.assertEqual(dfa.num_words(2), 4)
         self.assertEqual(
-            parsed.transitions, ((0, 1, 97), (1, 1, 98), (1, 1, 97))
+            [dfa.unrank(i, 2) for i in range(4)], [b"aa", b"ab", b"ba", b"bb"]
         )
-        self.assertEqual(parsed.symbols, (97, 98))  # sorted, deduplicated
+        self.assertEqual(dfa.rank(b"ba"), 2)
 
-    def test_parse_att_fst_rejects_no_states(self):
-        with self.assertRaises(InvalidFSTFormat):
-            parse_att_fst("")
-
-    def test_parse_att_fst_rejects_no_symbols(self):
-        # A lone final state gives a state set but no transitions/symbols.
-        with self.assertRaises(InvalidFSTFormat):
-            parse_att_fst("0")
-
-    def test_parse_att_fst_rejects_sparse_state_numbering(self):
-        # States {0, 2} skip 1, so the dense 0..N-1 check fails.
-        with self.assertRaises(InvalidFSTFormat):
-            parse_att_fst("0\t2\t97\t97\n2")
-
-    def test_parse_att_fst_rejects_malformed_line(self):
-        with self.assertRaises(InvalidFSTFormat):
-            parse_att_fst("0\t1\t2")   # 3 fields: neither transition nor final
-
-    def test_dfa_from_hand_built_parsed_fst(self):
+    def test_dfa_from_hand_built_fst(self):
         # Hand-built ``[01]+``: state 0 reads either bit to reach accepting
         # state 1, which loops on both. No regex2dfa involved.
-        parsed = ParsedFst(
-            start_state=0,
-            final_states=frozenset({1}),
-            transitions=(
-                (0, 1, 0x30), (0, 1, 0x31),
-                (1, 1, 0x30), (1, 1, 0x31),
-            ),
-            symbols=(0x30, 0x31),
+        dfa = DFA(
+            "0\t1\t48\t48\n"
+            "0\t1\t49\t49\n"
+            "1\t1\t48\t48\n"
+            "1\t1\t49\t49\n"
+            "1\n",
+            6,
         )
-        dfa = DFA(parsed, 6)
         self.assertEqual(dfa.num_words(0), 0)
         for length in range(1, 7):
             count = dfa.num_words(length)

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -7,18 +7,25 @@ import unittest
 from pathlib import Path
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# tests/ sits directly under the checkout, so the project root is one level
+# up. It goes on the child's PYTHONPATH so the child imports *this* fte
+# rather than whichever one happens to be installed.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 # Runs in a child interpreter with regex2dfa blocked: sys.modules[name] = None
 # makes any "import regex2dfa" raise ImportError, simulating an environment
 # where regex2dfa is not installed.
 CHILD_SCRIPT = """
+import os
 import sys
 
 sys.modules['regex2dfa'] = None
 
 import fte
 
+# sys.argv[1] is PROJECT_ROOT: the checkout's own package must be the one
+# imported, not an installed copy (and not a sibling of the checkout).
+assert fte.__file__.startswith(os.path.join(sys.argv[1], 'fte', '')), fte.__file__
 assert issubclass(fte.FTE, object)
 assert isinstance(fte.RankedFormat, type)
 
@@ -46,7 +53,7 @@ else:
 class Tests(unittest.TestCase):
     def test_import_fte_without_regex2dfa(self):
         result = subprocess.run(
-            [sys.executable, "-c", CHILD_SCRIPT],
+            [sys.executable, "-c", CHILD_SCRIPT, str(PROJECT_ROOT)],
             env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
             capture_output=True,
             text=True,


### PR DESCRIPTION
Two small items from the post-merge cleanup audit that get harder after 0.4.0 is tagged, plus a test fix. No behaviour change for rank/unrank/num_words: the corpus goldens and both wire-vector suites pass unchanged.

- **`parse_att_fst` / `ParsedFst` leave the public surface** of `fte.formats.regex.dfa`: renamed with a leading underscore and dropped from `__all__`; `DFA.__init__` takes only the AT&T FST string. The only producer and consumer were inside the module, and neither name shipped in a tagged release. `tests/test_dfa.py` now drives the parser through `DFA(...)`.
- **`BytesFormat` loses `__eq__`/`__hash__`.** The engine decides "same format" by fingerprint and detects the bytes input with `isinstance`; nothing in the library, tests, examples, or docs compared or hashed formats. The `fte` module docstring no longer describes FPE as `input_format == output_format`.
- **`tests/test_lazy_import.py` now tests the checkout.** Its project root was `parents[2]`, the parent of the repository, so the child interpreter never saw the checkout and the test passed against whichever `fte` was installed. It uses `parents[1]` and asserts the child's `fte.__file__` is under the checkout, which fails with the old root.

Verified: full suite (1362 passed, 0 skipped), doctests, all 11 examples, pyflakes clean; an adversarial review of the diff found nothing blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)