### PR TITLE
Raise the cryptography dependency floor to 50.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-    "cryptography>=41.0",
+    "cryptography>=50.0.0",
     "regex2dfa>=0.2.0",
     # The built-in cipher="ff1" (format-preserving, deterministic,
     # zero-expansion) is libffx's FF1; pure Python.


### PR DESCRIPTION
## Motivation

`pyproject.toml` declares `cryptography>=41.0`, which lets a resolver pinned to an older index snapshot install a release with known vulnerabilities. Checking the floor with pip-audit (OSV):

- `cryptography==41.0.0`: 17 known vulnerabilities (PYSEC-2023-112, PYSEC-2023-254, PYSEC-2024-225, PYSEC-2026-35, PYSEC-2026-1283/1285, PYSEC-2026-2141, PYSEC-2026-3553/3554, GHSA-jm77-qphf-c4w8, GHSA-v8gr-m533-ghj9, GHSA-h4gh-qq45-vh27, GHSA-537c-gmf6-5ccf)
- every line before 50.0.0 still carries at least one advisory (48.0.1 → PYSEC-2026-3553/3554 and PYSEC-2026-3552; 49.0.0 → PYSEC-2026-3552)

`cryptography==50.0.0` is the first release with no known vulnerabilities per OSV; the current latest, 50.0.1, is also clean.

## Compatibility

- cryptography 50.x requires Python >=3.9, so the project's >=3.10 floor is unaffected (existing CI matrix untouched).
- libfte only consumes AES-CTR from cryptography.

## Testing

- `python -m pytest -q`: 1363 passed, 101 subtests passed (against cryptography 50.0.1)
- `pip-audit` on the environment: no vulnerable project dependencies

Note: the `regex2dfa>=0.2.0` and `libffx>=2.0.0` floors audit clean and are left untouched.