### PR TITLE
Deprecate public custom cipher objects in FTE

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ fte.FTE(
 |-------------------|----------|-----|
 | `"aes-ctr-hmac"` | Randomized, authenticated encryption with a 29-byte frame overhead | 32 bytes: 16 for AES, 16 for HMAC |
 | `"ff1"` | Deterministic rank permutation using `libffx.FF1`, with no nonce or authentication tag | 16, 24, or 32 bytes |
-| Cipher object | A custom permutation with `encrypt_int(x, *, domain, tweak)` and `decrypt_int(y, *, domain, tweak)` | The object owns its key; `FTE` still requires a bytes `key` argument |
+| Cipher object **(deprecated)** | A custom permutation with `encrypt_int(x, *, domain, tweak)` and `decrypt_int(y, *, domain, tweak)`; construction emits `DeprecationWarning` | The object owns its key; the required bytes `FTE` key argument is unused |
 
 With `cipher=None`, a `BytesFormat` input selects `"aes-ctr-hmac"`. Otherwise,
 equal bytes fingerprints select `"ff1"`; any other format pair needs an explicit
@@ -51,6 +51,27 @@ input space raises `InvalidCovertextError`.
 cipher binds it to the formats and length mode. Authenticated encryption has no
 associated-data support and rejects a nonempty tweak. Never reuse keys across
 the two ciphers; see [SECURITY.md](../SECURITY.md).
+
+### Migrating custom cipher objects
+
+Passing a cipher object is deprecated. It remains accepted during the migration
+period and produces the same covertexts as before. The deprecation does not
+affect custom [format providers](formats.md).
+
+For new data, choose `cipher="ff1"` for deterministic encryption or
+`cipher="aes-ctr-hmac"` for authenticated encryption, and pass the encryption
+key directly to `FTE`. Authenticated encryption also requires enough output
+capacity for its frame; it cannot replace every deterministic configuration.
+
+A custom object can implement a different permutation, own a different key, or
+interpret tweaks differently from a built-in cipher. Changing its `cipher`
+argument to `"ff1"` is therefore **not generally ciphertext compatible**.
+Retain the original implementation, its key, format definitions, and tweaks to
+decrypt existing data. Migrate by decrypting with that configuration and
+encrypting with a separately configured named cipher. Keep track of which
+configuration produced each stored value; do not try to identify it by whether
+unauthenticated decryption returns a value in the format. No public replacement
+for arbitrary cipher injection is introduced.
 
 ### Plaintext limits
 

--- a/fte/core.py
+++ b/fte/core.py
@@ -7,6 +7,7 @@ reversible ordering of plaintext and covertext values.
 from __future__ import annotations
 
 import hashlib
+import warnings
 from typing import Generic, TypeVar
 
 from fte import frame
@@ -130,6 +131,12 @@ class FTE(Generic[Plaintext, Covertext]):
     bounded by the size of the input space rather than by the key, so the
     one-million floor is enforced on the input domain. Pass a distinct
     per-record ``tweak`` to separate encryptions.
+
+    Passing an object with ``encrypt_int()`` / ``decrypt_int()`` is deprecated
+    and emits :class:`DeprecationWarning`. Existing objects retain their behavior
+    and own their key; the ``FTE`` key argument is unused for them. Keep the
+    original object when decrypting old data: switching to a named cipher is
+    not generally ciphertext compatible.
     """
 
     _FRAME_VERSION = frame.FRAME_VERSION
@@ -197,7 +204,7 @@ class FTE(Generic[Plaintext, Covertext]):
                     "cannot infer cipher for this format pair; pass "
                     "cipher='ff1' for a deterministic transform, "
                     "cipher='aes-ctr-hmac' "
-                    "for authenticated encryption, or a cipher object"
+                    "for authenticated encryption"
                 )
 
         if isinstance(cipher, str):
@@ -207,9 +214,8 @@ class FTE(Generic[Plaintext, Covertext]):
                 cipher_mode = "deterministic"
             else:
                 raise ValueError(
-                    f"unknown cipher {cipher!r}; expected 'aes-ctr-hmac', "
-                    "'ff1', or an "
-                    "object with encrypt_int()/decrypt_int()"
+                    f"unknown cipher {cipher!r}; expected 'aes-ctr-hmac' "
+                    "or 'ff1'"
                 )
         else:
             if not callable(getattr(cipher, "encrypt_int", None)) or not callable(
@@ -264,6 +270,16 @@ class FTE(Generic[Plaintext, Covertext]):
                 )
             self._encrypter = Encrypter(key[:16], key[16:])
             self._init_ae_capacity(max_plaintext_bytes)
+
+        if not isinstance(cipher, str):
+            warnings.warn(
+                "Passing a cipher object to FTE is deprecated; use "
+                "cipher='ff1' or cipher='aes-ctr-hmac' for new data. "
+                "Keep the original cipher to decrypt existing "
+                "custom-cipher covertexts until migrated.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     # ------------------------------------------------------------------ #
     # Construction helpers                                               #

--- a/tests/test_engine_matrix.py
+++ b/tests/test_engine_matrix.py
@@ -1,12 +1,13 @@
 """The 2x2 engine matrix: {ff1/object, aes-ctr-hmac} x {input==output, input!=output}.
 
-These tests exercise :class:`fte.FTE` end to end without the real ``ffx``
+The matrix exercises :class:`fte.FTE` end to end without the real ``ffx``
 package. The deterministic cells use a duck-typed *toy* cipher object -- any
 object exposing ``encrypt_int(x, *, domain, tweak) -> int`` and
 ``decrypt_int(y, *, domain, tweak) -> int`` forming a permutation of
-``range(domain)`` is a valid cipher, which is both the test seam and the public
-extension point. The AE cells use the real, wire-frozen authenticated path over
-:class:`~fte.formats.regex.RegexFormat`.
+``range(domain)`` is accepted by the deprecated object-cipher path. These tests
+retain coverage of that behavior during migration. The AE cells use the real,
+wire-frozen authenticated path over :class:`~fte.formats.regex.RegexFormat`.
+The focused deprecation checks also construct the real named ciphers.
 
 The deterministic domain floor (one million) is always enforced, so the formats
 here are *computed* decimal-string languages large enough to clear it, and the
@@ -14,8 +15,10 @@ deterministic assertions sample rather than enumerate.
 """
 
 import hashlib
+import inspect
 import math
 import unittest
+import warnings
 
 import fte
 from fte import frame
@@ -220,7 +223,78 @@ KEY_UNUSED = b"ignored-for-object-cipher"
 BIG_HEX = fte.RegexFormat(r"^[0-9a-f]+$", length=256)
 
 
+class CustomCipherDeprecation(unittest.TestCase):
+    def test_warning_points_to_constructor_caller_and_occurs_once(self):
+        fmt = DigitsFormat(6, fingerprint=b"fp:legacy-custom")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            call_line = inspect.currentframe().f_lineno + 1
+            eng = FTE(input_format=fmt, output_format=fmt,
+                      cipher=ToyCipher(), key=b"")
+            self.assertEqual(eng.decrypt(eng.encrypt("123456")), "123456")
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
+        self.assertIn(
+            "Passing a cipher object to FTE is deprecated", str(caught[0].message)
+        )
+        self.assertIn("existing", str(caught[0].message))
+        self.assertEqual(caught[0].filename, __file__)
+        self.assertEqual(caught[0].lineno, call_line)
+
+    def test_existing_custom_cipher_covertexts_and_key_ownership_are_preserved(self):
+        fmt = DigitsFormat(6, fingerprint=b"fp:legacy-custom")
+        # Frozen before deprecation, using ToyCipher's own default key.
+        vectors = [
+            ("000000", b"", "214186"),
+            ("123456", b"record-A", "889261"),
+            ("999999", b"", "164859"),
+        ]
+        for key in (b"", bytes(range(32))):
+            with self.subTest(key=key):
+                with self.assertWarns(DeprecationWarning):
+                    eng = FTE(input_format=fmt, output_format=fmt,
+                              cipher=ToyCipher(), key=key)
+                for plaintext, tweak, covertext in vectors:
+                    self.assertEqual(eng.encrypt(plaintext, tweak=tweak), covertext)
+                    self.assertEqual(eng.decrypt(covertext, tweak=tweak), plaintext)
+
+    def test_named_ciphers_and_default_bytes_input_do_not_warn(self):
+        fmt = DigitsFormat(6, fingerprint=b"fp:d6")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            eng = FTE(input_format=fmt, output_format=fmt,
+                      cipher="ff1", key=bytes(range(16)))
+            self.assertEqual(eng.decrypt(eng.encrypt("123456")), "123456")
+            for cipher in ("aes-ctr-hmac", None):
+                eng = FTE(output_format=BIG_HEX, cipher=cipher, key=KEY_AE)
+                self.assertEqual(eng.decrypt(eng.encrypt(b"hello")), b"hello")
+        self.assertEqual(caught, [])
+
+    def test_invalid_objects_are_rejected_without_deprecation_warning(self):
+        fmt = DigitsFormat(6, fingerprint=b"fp:d6")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with self.assertRaisesRegex(TypeError, "callable encrypt_int"):
+                FTE(input_format=fmt, output_format=fmt, cipher=object(), key=b"")
+            small = DigitsFormat(5, fingerprint=b"fp:d5")
+            with self.assertRaises(SmallDomainError):
+                FTE(input_format=small, output_format=small,
+                    cipher=ToyCipher(), key=b"")
+        self.assertEqual(caught, [])
+
+
 class Tests(unittest.TestCase):
+    def setUp(self):
+        # The matrix keeps exercising legacy object behavior. Warning behavior
+        # is asserted separately above; do not hide any other deprecation.
+        context = warnings.catch_warnings()
+        context.__enter__()
+        self.addCleanup(context.__exit__, None, None, None)
+        warnings.filterwarnings(
+            "ignore", message="Passing a cipher object to FTE is deprecated;",
+            category=DeprecationWarning,
+        )
+
     # ---- deterministic, input == output (FPE cell) --------------------- #
     def test_deterministic_fpe_roundtrip_and_membership(self):
         fmt = DigitsFormat(6, fingerprint=b"fp:d6")


### PR DESCRIPTION
Passing an object as `FTE(cipher=...)` now emits a caller-attributed `DeprecationWarning` after successful construction. Named built-in ciphers remain warning-free, and legacy object permutations, tweaks, and key ownership keep their existing behavior during migration.

The API reference explains how to migrate new writes to a named cipher and retain the original implementation for old ciphertext. Substituting built-in FF1 for an arbitrary custom permutation is not generally compatible. Custom format providers remain supported; actual object-cipher removal is deferred to a future breaking release.

Validation: `python -m pytest -q -W error::DeprecationWarning` — 1,367 tests and 103 subtests passed. Includes frozen custom-cipher examples, warning attribution, invalid-object handling, and both built-in wire suites.

