### PR TITLE
Deprecate inferred FF1 selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,16 @@ max_length=400)` produces matching strings within that range.
 
 ## Format-preserving encryption
 
-Use the same finite format on both sides to infer `cipher="ff1"`:
+Use the same finite format on both sides and select `cipher="ff1"` explicitly:
 
 ```python
 import os
 import fte
 
 digits = fte.RegexFormat(r"^[0-9]+$", length=9)
-cipher = fte.FTE(input_format=digits, output_format=digits, key=os.urandom(16))
+cipher = fte.FTE(
+    input_format=digits, output_format=digits, key=os.urandom(16), cipher="ff1"
+)
 
 token = cipher.encrypt(b"100000042", tweak=b"account:42")
 assert len(token) == 9 and token.isdigit()

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,8 +33,12 @@ fte.FTE(
 | `"ff1"` | Deterministic rank permutation using `libffx.FF1`, with no nonce or authentication tag | 16, 24, or 32 bytes |
 | Cipher object | A custom permutation with `encrypt_int(x, *, domain, tweak)` and `decrypt_int(y, *, domain, tweak)` | The object owns its key; `FTE` still requires a bytes `key` argument |
 
-With `cipher=None`, a `BytesFormat` input selects `"aes-ctr-hmac"`. Otherwise,
-equal bytes fingerprints select `"ff1"`; any other format pair needs an explicit
+With `cipher=None`, a `BytesFormat` input selects `"aes-ctr-hmac"`. Select
+`cipher="ff1"` explicitly for deterministic, unauthenticated encryption.
+For compatibility, equal bytes fingerprints still infer `"ff1"`, but successful
+construction emits `DeprecationWarning`; this inference will be removed in a
+future breaking release. Adding `cipher="ff1"` preserves existing ciphertexts,
+keys, tweaks, and length behavior. Other format pairs already require an explicit
 cipher. See the [provider contract](formats.md) for custom formats.
 
 The deterministic cipher requires finite, fingerprinted formats with input

--- a/examples/10_fpe_digits.py
+++ b/examples/10_fpe_digits.py
@@ -26,7 +26,9 @@ def main():
     key = os.urandom(16)  # FF1 keys are 16/24/32 bytes; NOT an AES-CTR-HMAC key.
 
     # Same format in and out -> FPE. Length is preserved automatically.
-    cipher = fte.FTE(input_format=id_format, output_format=id_format, key=key)
+    cipher = fte.FTE(
+        input_format=id_format, output_format=id_format, key=key, cipher="ff1"
+    )
 
     # Synthetic demo identifiers (not real records).
     for account in (b"100000042", b"100000043", b"100000042"):

--- a/fte/__init__.py
+++ b/fte/__init__.py
@@ -2,7 +2,7 @@
 
 Use :class:`FTE` with :class:`RegexFormat`, :class:`BytesFormat`, or a custom
 :class:`RankedFormat`. Bytes input defaults to authenticated encryption;
-matching finite formats infer the deterministic FF1 cipher.
+pass ``cipher="ff1"`` explicitly for deterministic, unauthenticated encryption.
 
     >>> import fte
     >>> cipher = fte.FTE(

--- a/fte/core.py
+++ b/fte/core.py
@@ -7,6 +7,7 @@ reversible ordering of plaintext and covertext values.
 from __future__ import annotations
 
 import hashlib
+import warnings
 from typing import Generic, TypeVar
 
 from fte import frame
@@ -88,8 +89,8 @@ class FTE(Generic[Plaintext, Covertext]):
       ``FTE(output_format=fmt, key=key)`` is the classic pipeline: bytes in,
       the AE cipher, ``fmt`` out.
     * **FPE is the equal-formats case**: passing the same format as
-      ``input_format`` and ``output_format`` re-encrypts a value in place with
-      the deterministic cipher. Length is preserved automatically when the
+      ``input_format`` and ``output_format`` with ``cipher="ff1"`` re-encrypts
+      a value in place. Length is preserved automatically when the
       format can name its per-length slices (a ``slice_bounds`` method plus
       integer ``min_length`` / ``max_length``), so a value keeps its length;
       otherwise the whole language is permuted. See :attr:`preserve_length`.
@@ -97,7 +98,9 @@ class FTE(Generic[Plaintext, Covertext]):
       ``encrypt_int(x, *, domain, tweak) -> int`` /
       ``decrypt_int(y, *, domain, tweak) -> int``, or ``None`` to infer it:
       a bytes input picks ``"aes-ctr-hmac"``; otherwise two formats with equal
-      fingerprints pick ``"ff1"``; anything else must be spelled out.
+      fingerprints still pick ``"ff1"`` with a :class:`DeprecationWarning`.
+      Pass ``cipher="ff1"`` explicitly to select unauthenticated encryption;
+      anything else must be spelled out.
 
     The deterministic cipher refuses a domain below one million (Draft
     SP 800-38G Rev 1), raising :class:`SmallDomainError`, because FF1 is
@@ -183,6 +186,7 @@ class FTE(Generic[Plaintext, Covertext]):
         fp_out = getattr(output_format, "fingerprint", None)
 
         # ---- resolve the cipher ----------------------------------------
+        inferred_ff1 = False
         if cipher is None:
             if input_is_bytes:
                 cipher = "aes-ctr-hmac"
@@ -192,6 +196,7 @@ class FTE(Generic[Plaintext, Covertext]):
                 and fp_in == fp_out
             ):
                 cipher = "ff1"
+                inferred_ff1 = True
             else:
                 raise ValueError(
                     "cannot infer cipher for this format pair; pass "
@@ -256,6 +261,15 @@ class FTE(Generic[Plaintext, Covertext]):
 
         if cipher_mode == "deterministic":
             self._init_deterministic(cipher, key, fp_in, fp_out)
+            if inferred_ff1:
+                warnings.warn(
+                    "Implicit FF1 selection is deprecated and will be removed "
+                    "in a future breaking release; pass cipher='ff1' explicitly "
+                    "to select deterministic, unauthenticated encryption. "
+                    "Explicit selection preserves existing ciphertexts.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         else:
             if len(key) != 32:
                 raise ValueError(

--- a/tests/test_ff1_integration.py
+++ b/tests/test_ff1_integration.py
@@ -6,6 +6,7 @@ with a toy cipher object in ``test_engine_matrix.py``.
 """
 
 import unittest
+import warnings
 
 import fte
 from fte.core import FTE, InvalidCovertextError
@@ -30,7 +31,7 @@ class Tests(unittest.TestCase):
         # Equal formats over a length range: length preservation is inferred,
         # and every length slice (6..9 digits) clears the one-million floor.
         fmt = fte.RegexFormat(r"^[0-9]+$", min_length=6, max_length=9)
-        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY, cipher="ff1")
         self.assertTrue(eng.preserve_length)
         for pt in (b"123456", b"1234567", b"12345678", b"123456789"):
             ct = eng.encrypt(pt)
@@ -63,21 +64,46 @@ class Tests(unittest.TestCase):
         with self.assertRaises(InvalidCovertextError):
             eng.decrypt(ct, tweak=b"per-record-B")
 
-    def test_fpe_convenience_roundtrip(self):
+    def test_legacy_fpe_inference_warns_and_preserves_ciphertext(self):
         fmt = fte.RegexFormat(r"^[0-9]+$", length=16)
-        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY, cipher="ff1")
+        with self.assertWarnsRegex(DeprecationWarning, "pass cipher='ff1'") as warning:
+            legacy = fte.FTE(input_format=fmt, output_format=fmt, key=KEY)
+        self.assertEqual(warning.filename, __file__)
         pt = b"4111111111111111"
         ct = eng.encrypt(pt)
+        self.assertEqual(legacy.encrypt(pt), ct)
+        self.assertEqual(legacy.decrypt(ct), pt)
         self.assertEqual(len(ct), 16)
         self.assertEqual(eng.decrypt(ct), pt)
         # FPE with a distinct tweak separates the covertext.
         self.assertNotEqual(eng.encrypt(pt, tweak=b"x"), ct)
 
+    def test_explicit_ciphers_and_bytes_default_do_not_warn(self):
+        fmt = fte.RegexFormat(r"^[0-9]+$", length=6)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            explicit = fte.FTE(input_format=fmt, output_format=fmt,
+                               cipher="ff1", key=KEY)
+            authenticated = fte.FTE(output_format=fte.BytesFormat(),
+                                    cipher="aes-ctr-hmac", key=bytes(range(32)))
+            default = fte.FTE(output_format=fte.BytesFormat(), key=bytes(range(32)))
+        self.assertEqual(explicit.cipher, "deterministic")
+        self.assertEqual(authenticated.cipher, "aes-ctr-hmac")
+        self.assertEqual(default.cipher, "aes-ctr-hmac")
+
+    def test_invalid_inferred_domain_reports_original_error(self):
+        fmt = fte.RegexFormat(r"^[0-9]+$", length=5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with self.assertRaises(fte.SmallDomainError):
+                fte.FTE(input_format=fmt, output_format=fmt, key=KEY)
+
     def test_fpe_is_injective_on_a_sample(self):
         # The domain floor forbids tiny enumerable domains, so sample a
         # 10**6-word format and confirm distinct, in-format covertexts.
         fmt = fte.RegexFormat(r"^[0-9]+$", length=6)  # exactly 1e6 words
-        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=KEY, cipher="ff1")
         sample = [(i * 3607) % fmt.cardinality for i in range(256)]
         covertexts = {eng.encrypt(fmt.unrank(i)) for i in sample}
         self.assertEqual(len(covertexts), len(set(sample)))  # injective

--- a/tests/test_ff1_wire_compat.py
+++ b/tests/test_ff1_wire_compat.py
@@ -41,7 +41,7 @@ def _engine(vector, key=None):
     return fte.FTE(
         input_format=fin,
         output_format=fout,
-        cipher=vector["cipher"],
+        cipher=vector["cipher"] or "ff1",
         key=bytes.fromhex(vector["key_hex"]) if key is None else key,
     )
 
@@ -76,6 +76,25 @@ class FrozenVectors(unittest.TestCase):
                 self.assertEqual(eng.preserve_length, vector["preserve_length"])
                 self.assertEqual(eng.encrypt(plaintext, tweak=tweak), covertext)
                 self.assertEqual(eng.decrypt(covertext, tweak=tweak), plaintext)
+
+    def test_legacy_inference_keeps_frozen_covertexts(self):
+        for vector in _load_vectors():
+            if vector["cipher"] is not None:
+                continue
+            with self.subTest(input_pattern=vector["input_pattern"],
+                              length_kw=vector["input_length_kw"]):
+                explicit = _engine(vector)
+                with self.assertWarns(DeprecationWarning):
+                    legacy = fte.FTE(
+                        input_format=explicit.input_format,
+                        output_format=explicit.output_format,
+                        key=bytes.fromhex(vector["key_hex"]),
+                    )
+                plaintext = bytes.fromhex(vector["plaintext_hex"])
+                covertext = bytes.fromhex(vector["covertext_hex"])
+                tweak = bytes.fromhex(vector["tweak_hex"])
+                self.assertEqual(legacy.encrypt(plaintext, tweak=tweak), covertext)
+                self.assertEqual(legacy.decrypt(covertext, tweak=tweak), plaintext)
 
     def test_vectors_cover_both_length_modes(self):
         modes = {v["preserve_length"] for v in _load_vectors()}
@@ -120,7 +139,7 @@ class Composition(unittest.TestCase):
 
     def test_length_preserving_path_is_ff1_over_the_length_slice(self):
         fmt = fte.RegexFormat(r"^[0-9]+$", min_length=6, max_length=9)
-        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY, cipher="ff1")
         self.assertTrue(eng.preserve_length)
         tweak = b"orders.account"
         plaintext = b"1234567"
@@ -140,7 +159,7 @@ class Composition(unittest.TestCase):
         # encrypt(pt) with no tweak is encrypt(pt, tweak=b""): the derived base
         # is used bare, with nothing appended.
         fmt = fte.RegexFormat(r"^[0-9]+$", length=16)
-        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY)
+        eng = fte.FTE(input_format=fmt, output_format=fmt, key=self.KEY, cipher="ff1")
         plaintext = b"4111111111111111"
         self.assertEqual(eng.encrypt(plaintext), eng.encrypt(plaintext, tweak=b""))
         offset, count = fmt.slice_bounds(16)


### PR DESCRIPTION
Omitting `cipher` with matching finite formats currently selects deterministic, unauthenticated FF1. Successful inferred construction now emits `DeprecationWarning` asking callers to pass `cipher="ff1"` explicitly; the README and runnable FPE example use that explicit form.

The bytes-input authenticated default remains available. Existing inferred FF1 configurations still produce and decrypt the same ciphertexts during migration; omission will be rejected in a future breaking release instead of changing modes.

Validation: `python -m pytest -q -W error::DeprecationWarning` — 1,366 tests and 106 subtests passed. Frozen vectors exercise both explicit FF1 and legacy inference, with warning attribution and original invalid-domain errors covered.

